### PR TITLE
feat(refine): 新增炼化插件

### DIFF
--- a/src/plugins/refine/README.md
+++ b/src/plugins/refine/README.md
@@ -1,0 +1,176 @@
+# refine 炼化插件
+
+订阅某个群聊发言人或 `un_nickname` 集合，按 cron 周期性通过 AI 提炼目标近期发言，生成简要总结，落库保留 N 天（默认 3）。**不主动推送** — 用户必须用 `炼化查询` 命令拉取结果。
+
+- 数据源：复用 `message_archive` 归档表（不重复存储原始消息）
+- 订阅对象：单用户（`user:<qq>` 或 `@某人`）或 `un_nickname` 集合（`collection:<名>` / `集合 <名>`）
+- AI 接口：OpenAI 兼容 `chat/completions`（同 `a_share_sentiment`）
+- 命令权限：所有人可用；分群权限由 `refine_group_*` 控制
+
+---
+
+## 配置项
+
+在 `.env`（或环境变量）配置：
+
+| 环境变量 | 默认值 | 说明 |
+|---------|-------|------|
+| `REFINE_PLUGIN_ENABLED` | `false` | 是否启用炼化插件 |
+| `REFINE_GROUP_MODE` | `all` | 群组控制模式：`all`/`whitelist`/`blacklist` |
+| `REFINE_GROUP_WHITELIST` | `[]` | 白名单群（whitelist 模式生效） |
+| `REFINE_GROUP_BLACKLIST` | `[]` | 黑名单群（blacklist 模式生效） |
+| `REFINE_AI_BASE_URL` | `""` | OpenAI 兼容接口 Base URL（如 `https://api.openai.com/v1`） |
+| `REFINE_AI_API_KEY` | `""` | API Key |
+| `REFINE_AI_MODEL` | `""` | 模型名（如 `gpt-4o-mini`） |
+| `REFINE_AI_TIMEOUT_SECONDS` | `30.0` | AI 请求超时（秒） |
+| `REFINE_AI_TEMPERATURE` | `0.3` | AI 采样温度 |
+| `REFINE_RESULT_RETENTION_DAYS` | `3` | 结果保留天数（超期自动清理） |
+| `REFINE_SCHEDULE_CRON_HOUR` | `8` | 每日定时提炼的小时（0-23） |
+| `REFINE_SCHEDULE_CRON_MINUTE` | `0` | 每日定时提炼的分钟（0-59） |
+| `REFINE_LOOKBACK_HOURS` | `24` | 每次提炼回看小时数（1-168） |
+| `REFINE_MAX_MESSAGES_PER_TARGET` | `200` | 单目标每次采样上限 |
+| `REFINE_MAX_PROMPT_CHARS` | `12000` | prompt 中原文总字符预算 |
+| `REFINE_MIN_MESSAGES_TO_REFINE` | `5` | 目标在窗口内消息数不足此值时跳过（节省 AI 调用） |
+
+### 启用步骤
+
+```dotenv
+REFINE_PLUGIN_ENABLED=true
+REFINE_AI_BASE_URL=https://api.openai.com/v1
+REFINE_AI_API_KEY=sk-xxx
+REFINE_AI_MODEL=gpt-4o-mini
+```
+
+---
+
+## 前置依赖
+
+依赖两个内置插件：
+
+- **`message_archive`** — 提供发言原文（按时间窗 + 群号）。未启用时本插件采集结果为空。
+- **`un_nickname`** — 提供 `集合` 数据（订阅类型 `collection` 时）。不使用集合订阅时可缺失。
+
+两者均已在 `pyproject.toml` 的 `plugin_dirs` 下，无需额外安装。
+
+---
+
+## 命令列表
+
+| 命令 | 参数 | 说明 |
+|------|------|------|
+| `炼化订阅` | `<标签> <目标>` | 新增订阅。目标写法见下 |
+| `炼化订阅列表` | - | 列出本群所有订阅 |
+| `炼化取消订阅` | `<标签>` | 删除订阅（同时级联删除其历史结果） |
+| `炼化查询` | `[标签]` | 不带标签列出本群所有订阅最新摘要；带标签返回完整结果 |
+| `炼化刷新` | `<标签>` | 立即重新提炼（不等 cron，覆盖最新结果） |
+| `炼化帮助` | - | 帮助 |
+
+### 订阅目标写法
+
+| 写法 | 含义 |
+|------|------|
+| `user:123456` | 订阅 QQ 为 123456 的用户 |
+| `123456` | 同上的简写（纯数字自动识别） |
+| `collection:小组A` | 订阅名为 `小组A` 的 un_nickname 集合 |
+| `集合 小组A` | 同上的中文别名 |
+| 直接 `@某人` | 命令消息中 @ 该用户，等价于 `user:<其QQ>` |
+
+### 标签规则
+
+- 同一群内 `(target_type, target_value)` 唯一：一个目标不能被订阅两次
+- 同一群内 `label` 唯一：标签是查询/取消的句柄
+- 标签建议简短好记（如 `张三`、`打板群`、`核心团队`）
+
+---
+
+## 用法示例
+
+**订阅单用户**（任意一种写法等价）：
+
+```
+炼化订阅 张三 user:123456
+炼化订阅 张三 123456
+炼化订阅 张三 @张三本人
+```
+
+**订阅集合**（先用 un_nickname 创建集合）：
+
+```
+集合 核心 @张三 @李四 @王五
+炼化订阅 核心团队 collection:核心
+炼化订阅 核心团队 集合 核心
+```
+
+**查询最新结果**：
+
+```
+炼化查询 张三
+```
+
+输出（懒触发，只有这里才推送给用户）：
+
+```
+🧪 炼化结果：[张三]
+目标：用户=123456
+采样窗口：2026-07-20 08:00 ~ 07-21 08:00
+采样消息：42 条
+模型：gpt-4o-mini
+
+张三在过去 24 小时主要讨论了...（AI 生成）
+```
+
+**列出本群所有订阅的最新摘要**：
+
+```
+炼化查询
+```
+
+输出：
+
+```
+📋 本群 3 个订阅的最新结果:
+  • [张三] (2026-07-21 08:01, 42条): 张三讨论了行情、操作和心态...
+  • [核心团队] (2026-07-21 08:02, 87条): 团队成员集中关注 XX 板块...
+  • [新手群] 暂无结果（等待定时提炼或炼化刷新）
+
+使用 `炼化查询 <标签>` 查看完整结果
+```
+
+**立即重新提炼**：
+
+```
+炼化刷新 张三
+```
+
+---
+
+## 工作机制
+
+1. **采集**（`collector.py`）：按订阅的 `lookback_hours` 窗口从 `message_archive` 拉群消息，按 `user_id` 过滤；订阅为 `collection` 时先从 `nickname_collections` 拿成员列表再过滤。
+2. **Prompt 构建**（`collector.build_prompt_payload`）：每条消息渲染为 `[MM-DD HH:MM] <昵称>: <文本>`，整体截断到 `max_prompt_chars`。
+3. **AI 调用**（`ai.py`）：OpenAI 兼容 `chat/completions`，system prompt 指示生成 300 字内中文总结。
+4. **落库**（`db.add_result`）：结果与订阅 id、时间窗、消息数、模型名绑定。
+5. **懒触发**（`commands._query`）：用户查询时才把最新结果发到群里。
+6. **清理**（`runner.run_purge`）：每日 04:30 清理创建超过 `retention_days` 的结果。
+
+### 跳过 AI 调用的条件
+
+为节省 token，下列情况不调用 AI，结果保持上次：
+
+- 目标在窗口内消息数 < `refine_min_messages_to_refine`（默认 5）
+- 订阅为 `collection` 但 un_nickname 集合已不存在/为空
+- `message_archive` 在该窗口内对该群没有任何归档
+
+---
+
+## 故障排查
+
+| 现象 | 可能原因 | 解决 |
+|------|---------|------|
+| 启动日志 `配置缺失: refine_ai_*` | 未填 base_url/key/model | 补齐 `.env` 配置 |
+| `❌ AI 配置缺失` | 刷新命令时再次校验失败 | 同上 |
+| `⚠️ [...] 提炼未完成：消息不足` | 目标在窗口内发言太少 | 调小 `REFINE_MIN_MESSAGES_TO_REFINE` 或等目标多说话 |
+| `⚠️ [...] 提炼未完成：AI 请求超时` | 模型/网络慢 | 调大 `REFINE_AI_TIMEOUT_SECONDS` |
+| `⚠️ [...] 提炼未完成：AI 鉴权失败` | api_key 错误 | 检查 `REFINE_AI_API_KEY` |
+| `集合「xxx」不存在或无成员` | 订阅时引用了未创建的集合 | 先用 `集合 xxx @人` 创建 |
+| `炼化查询` 显示 `暂无结果` | 还没到下一次 cron；或上次提炼被跳过 | 用 `炼化刷新 <标签>` 立即触发 |

--- a/src/plugins/refine/__init__.py
+++ b/src/plugins/refine/__init__.py
@@ -1,0 +1,88 @@
+from nonebot import get_driver, get_plugin_config, logger, require
+from nonebot.plugin import PluginMetadata
+
+from .config import Config
+
+__plugin_meta__ = PluginMetadata(
+    name="refine",
+    description="炼化：订阅群聊发言人/集合，周期性 AI 提炼总结，懒触发查询",
+    usage=(
+        "炼化订阅 <标签> <user:qq | collection:名 | 集合 名 | @某人>\n"
+        "炼化订阅列表\n"
+        "炼化取消订阅 <标签>\n"
+        "炼化查询 [标签]    # 不带标签则列出本群所有订阅的最新摘要\n"
+        "炼化刷新 <标签>    # 立即重新提炼（覆盖最新结果）\n"
+        "炼化帮助"
+    ),
+    config=Config,
+)
+
+config: Config = get_plugin_config(Config)
+driver = get_driver()
+aps = require("nonebot_plugin_apscheduler")
+aps_scheduler = aps.scheduler
+
+
+def _collect_missing_ai_config() -> list[str]:
+    """若启用插件但缺 AI 配置，返回缺失字段名列表；否则返回空。"""
+    if not config.refine_plugin_enabled:
+        return []
+    missing: list[str] = []
+    if not config.refine_ai_base_url.strip():
+        missing.append("refine_ai_base_url")
+    if not config.refine_ai_api_key.strip():
+        missing.append("refine_ai_api_key")
+    if not config.refine_ai_model.strip():
+        missing.append("refine_ai_model")
+    return missing
+
+
+@driver.on_startup
+async def _init_refine() -> None:
+    """启动时：建表 + 注册 cron（条件性）。
+
+    缺 AI 配置仅警告，不阻止加载（订阅命令仍可用，刷新会给出明确错误）。
+    插件未启用时直接跳过 cron 注册，避免空跑。
+    """
+    from .db import ensure_schema  # noqa: PLC0415
+
+    ensure_schema()
+
+    missing = _collect_missing_ai_config()
+    if missing:
+        logger.warning(
+            f"[refine] 配置缺失: {', '.join(missing)}。"
+            "定时提炼与即时刷新不可用，订阅管理命令仍可用。"
+        )
+
+    if not config.refine_plugin_enabled:
+        logger.info("[refine] 插件未启用，跳过注册 cron")
+        return
+
+    from .runner import run_daily_refine, run_purge  # noqa: PLC0415
+
+    @aps_scheduler.scheduled_job(
+        "cron",
+        hour=config.refine_schedule_cron_hour,
+        minute=config.refine_schedule_cron_minute,
+    )
+    async def _daily_refine_job() -> None:
+        try:
+            outcomes = await run_daily_refine(config)
+            ok = sum(1 for o in outcomes if o.success)
+            skipped = sum(1 for o in outcomes if not o.success)
+            logger.info(
+                f"[refine] 每日提炼完成: 成功 {ok} 个，跳过/失败 {skipped} 个"
+            )
+        except Exception as e:
+            logger.exception(f"[refine] 每日提炼任务异常: {e}")
+
+    @aps_scheduler.scheduled_job("cron", hour=4, minute=30)
+    async def _daily_purge_job() -> None:
+        try:
+            await run_purge(config)
+        except Exception as e:
+            logger.exception(f"[refine] 清理任务异常: {e}")
+
+
+from . import commands  # noqa: E402  # register matchers

--- a/src/plugins/refine/ai.py
+++ b/src/plugins/refine/ai.py
@@ -1,0 +1,130 @@
+"""OpenAI 兼容 chat/completions 调用。
+
+参考 ``src/plugins/a_share_sentiment/ai.py``，但简化：本插件不要求 JSON 结构化
+输出，直接返回一段自然语言总结即可（降低对模型的提示工程依赖，便于换底层）。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+from nonebot import logger
+
+from .exceptions import (
+    RefineAIAuthError,
+    RefineAIResponseError,
+    RefineAIServiceError,
+    RefineAITimeoutError,
+)
+
+
+def build_chat_completions_url(base_url: str) -> str:
+    """把 base_url 拼成 chat/completions 端点。
+
+    兼容两种填法：``https://api.openai.com/v1`` 与
+    ``https://api.openai.com/v1/``，都得到 ``.../v1/chat/completions``。
+    """
+    return f"{base_url.rstrip('/')}/chat/completions"
+
+
+def build_system_prompt() -> str:
+    return (
+        "你是一名擅长从聊天记录中提炼信息的助理。"
+        "用户会给你某个群聊目标的近期发言原文，请生成一份简明中文总结："
+        "（1）该目标讨论的核心话题；（2）表达过的观点或态度；"
+        "（3）值得关注的具体信息（链接、数字、承诺、计划）。"
+        "只基于给定原文，不要编造未出现的内容；信息不足时直接说明。"
+        "输出纯文本，不要 Markdown 标题，不要额外解释，300 字以内。"
+    )
+
+
+def build_user_prompt(prompt_payload: str) -> str:
+    return f"目标近期发言原文如下：\n{prompt_payload}"
+
+
+def extract_response_content(payload: dict[str, Any]) -> str:
+    """从 OpenAI chat/completions 响应中抽出 message.content 字符串。
+
+    兼容 string content 和 OpenAI 新版 array content（text 段拼接）。
+    """
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RefineAIResponseError("响应中缺少 choices")
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        raise RefineAIResponseError("响应中的 choice 格式不正确")
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        raise RefineAIResponseError("响应中缺少 message")
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        text_parts = [
+            item["text"]
+            for item in content
+            if isinstance(item, dict)
+            and item.get("type") == "text"
+            and isinstance(item.get("text"), str)
+        ]
+        if text_parts:
+            return "".join(text_parts).strip()
+    raise RefineAIResponseError("响应中缺少可解析的 content")
+
+
+async def request_refine_summary(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    timeout_seconds: float,
+    temperature: float,
+    prompt_payload: str,
+) -> str:
+    """调用 AI 生成总结。失败抛 RefineAIError 子类。"""
+    request_url = build_chat_completions_url(base_url)
+    request_body = {
+        "model": model,
+        "temperature": temperature,
+        "messages": [
+            {"role": "system", "content": build_system_prompt()},
+            {"role": "user", "content": build_user_prompt(prompt_payload)},
+        ],
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds, trust_env=False) as client:
+            response = await client.post(
+                request_url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=request_body,
+            )
+            response.raise_for_status()
+    except httpx.TimeoutException as e:
+        raise RefineAITimeoutError("AI 请求超时") from e
+    except httpx.HTTPStatusError as e:
+        status_code = e.response.status_code
+        if status_code in {401, 403}:
+            raise RefineAIAuthError("AI 鉴权失败") from e
+        raise RefineAIServiceError(f"AI 服务返回 HTTP {status_code}") from e
+    except httpx.RequestError as e:
+        raise RefineAIServiceError(f"AI 请求失败: {e}") from e
+
+    try:
+        payload = response.json()
+    except json.JSONDecodeError as e:
+        raise RefineAIResponseError("AI 接口返回的不是合法 JSON") from e
+
+    if not isinstance(payload, dict):
+        raise RefineAIResponseError("AI 接口响应格式不正确")
+
+    content = extract_response_content(payload)
+    logger.debug(f"[炼化] AI 原始输出: {content[:200]}")
+    if not content:
+        raise RefineAIResponseError("AI 输出内容为空")
+    return content

--- a/src/plugins/refine/collector.py
+++ b/src/plugins/refine/collector.py
@@ -1,0 +1,185 @@
+"""发言采集器：从 message_archive 取目标发言，拼装成 AI prompt。
+
+依赖 ``message_archive`` 插件的 DB API（``fetch_group_messages_by_time_range``）。
+message_archive 表未初始化时直接返回空（容错）。
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from nonebot import logger
+
+from .db import RefineSubscription, TargetType
+
+if TYPE_CHECKING:
+    from .config import Config
+
+
+@dataclass(slots=True)
+class CollectedMessages:
+    """采集结果。``messages`` 已截断到 max_messages。"""
+
+    messages: list[tuple[int, str, str]]  # (event_time, sender_name, plain_text)
+    period_start: int
+    period_end: int
+
+
+async def _fetch_un_nickname_collection_members(
+    group_id: str, collection_name: str
+) -> list[str]:
+    """懒加载避免循环 import。返回空列表表示集合不存在或 un_nickname 未加载。"""
+    try:
+        from src.plugins.un_nickname.db import (  # noqa: PLC0415
+            fetch_collection_members,
+        )
+    except ImportError:
+        logger.warning("[炼化] un_nickname 插件未加载，无法解析 collection 订阅")
+        return []
+    return await fetch_collection_members(group_id, collection_name)
+
+
+async def collect_messages_for_subscription(
+    sub: RefineSubscription,
+    *,
+    lookback_hours: int,
+    max_messages: int,
+    max_prompt_chars: int,  # 保留参数以保持调用方对称
+    period_end: int | None = None,
+) -> CollectedMessages:
+    """采集一个订阅在回看窗口内的发言。"""
+    end = period_end if period_end is not None else int(time.time())
+    start = end - lookback_hours * 3600
+
+    if sub.target_type == "user":
+        user_ids: list[str] = [sub.target_value]
+    else:
+        user_ids = await _fetch_un_nickname_collection_members(
+            sub.group_id, sub.target_value
+        )
+        if not user_ids:
+            return CollectedMessages(messages=[], period_start=start, period_end=end)
+
+    try:
+        from src.plugins.message_archive.db import (  # noqa: PLC0415
+            fetch_group_messages_by_time_range,
+        )
+
+        archived = await fetch_group_messages_by_time_range(
+            group_id=sub.group_id,
+            start_time=start,
+            end_time=end,
+        )
+    except Exception as e:
+        logger.warning(f"[炼化] 读取 message_archive 失败: {e}")
+        return CollectedMessages(messages=[], period_start=start, period_end=end)
+
+    target_set = set(user_ids)
+    picked: list[tuple[int, str, str]] = []
+    for msg in archived:
+        if msg.user_id not in target_set:
+            continue
+        text = msg.plain_text.strip()
+        if not text:
+            continue
+        picked.append((msg.event_time, msg.sender_name, text))
+        if len(picked) >= max_messages:
+            break
+
+    return CollectedMessages(messages=picked, period_start=start, period_end=end)
+
+
+def build_prompt_payload(
+    collected: CollectedMessages, *, max_prompt_chars: int
+) -> str:
+    """把采集到的消息渲染成 prompt 原文段落。
+
+    每条格式: ``[MM-DD HH:MM] <昵称>: <文本>``，整体截断到 max_prompt_chars。
+    """
+    if not collected.messages:
+        return ""
+    lines: list[str] = []
+    total = 0
+    for event_time, name, text in collected.messages:
+        local = time.strftime("%m-%d %H:%M", time.localtime(event_time))
+        line = f"[{local}] {name}: {text}"
+        if total + len(line) + 1 > max_prompt_chars:
+            remaining = max_prompt_chars - total
+            if remaining <= 0:
+                break
+            line = line[:remaining]
+            lines.append(line)
+            break
+        lines.append(line)
+        total += len(line) + 1
+    return "\n".join(lines)
+
+
+async def collect_and_build_payload(
+    sub: RefineSubscription,
+    config: Config,
+) -> tuple[CollectedMessages, str]:
+    """一站式：采集 + 拼 prompt。返回 (collected, prompt_payload)。
+
+    prompt_payload 为空字符串表示目标在回看窗口内没有任何发言（跳过 AI 调用）。
+    """
+    collected = await collect_messages_for_subscription(
+        sub,
+        lookback_hours=config.refine_lookback_hours,
+        max_messages=config.refine_max_messages_per_target,
+        max_prompt_chars=config.refine_max_prompt_chars,
+    )
+    if not collected.messages:
+        return collected, ""
+    payload = build_prompt_payload(
+        collected, max_prompt_chars=config.refine_max_prompt_chars
+    )
+    return collected, payload
+
+
+def _parse_prefix_value(text: str) -> tuple[TargetType, str] | tuple[None, None]:
+    """处理 ``prefix:value`` 形式。"""
+    prefix, _, rest = text.partition(":")
+    prefix = prefix.strip().lower()
+    rest = rest.strip()
+    if not rest:
+        return None, None
+    if prefix in {"collection", "集合"}:
+        return "collection", rest
+    if prefix == "user":
+        return "user", rest
+    return None, None
+
+
+def resolve_target_type_and_value(
+    raw_arg: str,
+) -> tuple[TargetType, str] | tuple[None, None]:
+    """解析用户输入的订阅目标。
+
+    支持两种形式:
+        collection:<名>           -> ('collection', '<名>')
+        集合 <名> / 集合<名>      -> ('collection', '<名>')  (中文别名)
+        user:<qq>                 -> ('user', '<qq>')
+        纯数字                    -> ('user', '<qq>')
+
+    返回 (None, None) 表示格式不识别。
+    """
+    text = raw_arg.strip()
+    if not text:
+        return None, None
+
+    if ":" in text:
+        return _parse_prefix_value(text)
+
+    if text.startswith("集合"):
+        rest = text[2:].strip()
+        if rest:
+            return "collection", rest
+        return None, None
+
+    if text.isdigit():
+        return "user", text
+
+    return None, None

--- a/src/plugins/refine/commands.py
+++ b/src/plugins/refine/commands.py
@@ -1,0 +1,335 @@
+"""炼化插件命令 handlers。
+
+6 个命令:
+- ``炼化订阅 <标签> <user:qq | collection:名 | 集合 名>``  新增订阅
+- ``炼化订阅列表``                                          列出本群订阅
+- ``炼化取消订阅 <标签>``                                   删除订阅
+- ``炼化查询 [标签]``                                       拉取最新结果（懒触发）
+- ``炼化刷新 <标签>``                                       立刻触发一次提炼
+- ``炼化帮助``                                              帮助
+
+权限: 所有用户可用（与 trawler 保持一致）。群权限由 group_rule 控制。
+
+注意: ``config`` 实例从 ``__init__.py`` 复用，避免每次 ``get_plugin_config`` 新建
+实例导致测试 setattr 与 group_rule 闭包取到不同实例。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from nonebot import on_command
+from nonebot.adapters.onebot.v11 import (
+    GroupMessageEvent,
+    Message,
+)
+from nonebot.params import CommandArg
+
+# 复用 __init__.py 中已实例化的 config 对象，避免 get_plugin_config 每次新建实例
+# 导致测试 setattr 与 group_rule 闭包取到不同实例。
+import src.plugins.refine as _refine_pkg
+
+from ..group_permission import create_group_rule
+from .collector import resolve_target_type_and_value
+from .config import Config
+from .db import (
+    RefineSubscription,
+    add_subscription,
+    conflict_on_label,
+    conflict_on_target,
+    delete_subscription,
+    get_latest_result,
+    get_subscription_by_label,
+    list_subscriptions,
+)
+from .exceptions import RefineConfigError
+from .runner import _validate_ai_config, refine_single_subscription
+
+config: Config = _refine_pkg.config
+
+# ── 命令注册 ──────────────────────────────────────────
+refine_group_rule = create_group_rule(
+    config_getter=lambda: config,
+    plugin_enabled_attr="refine_plugin_enabled",
+    prefix="refine_",
+)
+
+refine_subscribe = on_command("炼化订阅", rule=refine_group_rule, block=True)
+refine_list = on_command("炼化订阅列表", rule=refine_group_rule, block=True)
+refine_unsubscribe = on_command("炼化取消订阅", rule=refine_group_rule, block=True)
+refine_query = on_command("炼化查询", rule=refine_group_rule, block=True)
+refine_refresh = on_command("炼化刷新", rule=refine_group_rule, block=True)
+refine_help = on_command("炼化帮助", rule=refine_group_rule, block=True)
+
+
+# ── 工具函数 ──────────────────────────────────────────
+
+
+def _extract_at_qq(message: Message) -> str | None:
+    """从消息段中抽取第一个 @ 用户 QQ。"""
+    for seg in message:
+        if seg.type == "at" and seg.data.get("qq"):
+            return str(seg.data["qq"])
+    return None
+
+
+def _format_subscription_line(sub: RefineSubscription) -> str:
+    type_label = "用户" if sub.target_type == "user" else "集合"
+    return (
+        f"  • [{sub.label}] {type_label}={sub.target_value}"
+        f"  (创建于 {datetime.fromtimestamp(sub.created_at).strftime('%Y-%m-%d %H:%M')})"
+    )
+
+
+def _format_result_block(
+    sub: RefineSubscription, result, members: list[str] | None = None
+) -> str:  # type: ignore[no-untyped-def]
+    period_start_str = datetime.fromtimestamp(result.period_start).strftime(
+        "%Y-%m-%d %H:%M"
+    )
+    period_end_str = datetime.fromtimestamp(result.period_end).strftime("%m-%d %H:%M")
+    type_label = "用户" if sub.target_type == "user" else "集合"
+
+    lines = [
+        f"🧪 炼化结果：[{sub.label}]",
+        f"目标：{type_label}={sub.target_value}",
+    ]
+    if members is not None and sub.target_type == "collection":
+        lines.append(f"集合成员：{len(members)} 人")
+    lines.extend(
+        [
+            f"采样窗口：{period_start_str} ~ {period_end_str}",
+            f"采样消息：{result.message_count} 条",
+            f"模型：{result.model_name}",
+            "",
+            result.summary,
+        ]
+    )
+    return "\n".join(lines)
+
+
+async def _resolve_collection_members(
+    group_id: str, collection_name: str
+) -> list[str]:
+    """容错版本：un_nickname 未加载时返回空。"""
+    try:
+        from src.plugins.un_nickname.db import (  # noqa: PLC0415
+            fetch_collection_members,
+        )
+    except ImportError:
+        return []
+    return await fetch_collection_members(group_id, collection_name)
+
+
+# ── Handlers ─────────────────────────────────────────
+
+
+@refine_subscribe.handle()
+async def _subscribe(event: GroupMessageEvent, args: Message = CommandArg()) -> None:
+    raw = args.extract_plain_text().strip()
+
+    at_qq = _extract_at_qq(args)
+
+    if at_qq:
+        label = raw.split()[0] if raw.split() else ""
+        target_type = "user"
+        target_value = at_qq
+    else:
+        parts = raw.split()
+        if len(parts) < 2:
+            await refine_subscribe.finish(
+                "用法：炼化订阅 <标签> <user:qq | collection:名 | 集合 名 | @某人>"
+            )
+            return
+        label = parts[0]
+        rest = " ".join(parts[1:])
+        resolved = resolve_target_type_and_value(rest)
+        if resolved[0] is None:
+            await refine_subscribe.finish(
+                "无法识别订阅目标。支持的写法：\n"
+                "  user:<qq>\n"
+                "  collection:<名>\n"
+                "  集合 <名>\n"
+                "  或直接 @某人"
+            )
+            return
+        target_type = resolved[0]
+        target_value = resolved[1]
+
+    if not label:
+        await refine_subscribe.finish("请指定订阅标签")
+
+    group_id = str(event.group_id)
+
+    if target_type == "collection":
+        members = await _resolve_collection_members(group_id, target_value)
+        if not members:
+            await refine_subscribe.finish(
+                f"集合「{target_value}」不存在或无成员。"
+                "请先用 un_nickname 插件的 `集合 <名> @人` 命令创建。"
+            )
+            return
+
+    dup_target = await conflict_on_target(group_id, target_type, target_value)
+    if dup_target is not None:
+        await refine_subscribe.finish(
+            f"该目标已被订阅，标签为「{dup_target.label}」"
+        )
+        return
+    dup_label = await conflict_on_label(group_id, label)
+    if dup_label is not None:
+        await refine_subscribe.finish(f"标签「{label}」已被使用，请换一个")
+
+    sub = await add_subscription(
+        group_id=group_id,
+        target_type=target_type,
+        target_value=target_value,
+        label=label,
+    )
+    if sub is None:  # pragma: no cover
+        await refine_subscribe.finish("订阅失败（可能存在并发冲突，请重试）")
+        return
+
+    type_label = "用户" if target_type == "user" else "集合"
+    await refine_subscribe.finish(
+        f"✅ 已订阅 [{label}] ({type_label}={target_value})\n"
+        f"下次定时提炼：每日 {config.refine_schedule_cron_hour:02d}:"
+        f"{config.refine_schedule_cron_minute:02d}\n"
+        f"若需立即生成结果，发送：炼化刷新 {label}"
+    )
+
+
+@refine_list.handle()
+async def _list(event: GroupMessageEvent) -> None:
+    subs = await list_subscriptions(str(event.group_id))
+    if not subs:
+        await refine_list.finish("本群暂无炼化订阅。发送 `炼化订阅 <标签> @某人` 添加")
+        return
+    lines = [f"📌 本群共 {len(subs)} 个炼化订阅:"]
+    for sub in subs:
+        lines.append(_format_subscription_line(sub))
+    lines.append("\n使用 `炼化查询 [标签]` 查看最新结果")
+    await refine_list.finish("\n".join(lines))
+
+
+@refine_unsubscribe.handle()
+async def _unsubscribe(event: GroupMessageEvent, args: Message = CommandArg()) -> None:
+    label = args.extract_plain_text().strip()
+    if not label:
+        await refine_unsubscribe.finish("用法：炼化取消订阅 <标签>")
+        return
+    ok = await delete_subscription(group_id=str(event.group_id), label=label)
+    if ok:
+        await refine_unsubscribe.finish(f"✅ 已取消订阅 [{label}]，历史结果一并删除")
+    else:
+        await refine_unsubscribe.finish(f"未找到标签为「{label}」的订阅")
+
+
+@refine_query.handle()
+async def _query(event: GroupMessageEvent, args: Message = CommandArg()) -> None:
+    label = args.extract_plain_text().strip()
+    group_id = str(event.group_id)
+
+    if not label:
+        subs = await list_subscriptions(group_id)
+        if not subs:
+            await refine_query.finish("本群暂无订阅")
+            return
+        lines = [f"📋 本群 {len(subs)} 个订阅的最新结果:"]
+        for sub in subs:
+            result = await get_latest_result(sub.id)
+            if result is None:
+                lines.append(f"  • [{sub.label}] 暂无结果（等待定时提炼或炼化刷新）")
+            else:
+                preview = result.summary.replace("\n", " ")[:60]
+                ts = datetime.fromtimestamp(result.created_at).strftime(
+                    "%Y-%m-%d %H:%M"
+                )
+                lines.append(
+                    f"  • [{sub.label}] ({ts}, {result.message_count}条): {preview}..."
+                )
+        lines.append("\n使用 `炼化查询 <标签>` 查看完整结果")
+        await refine_query.finish("\n".join(lines))
+        return
+
+    sub = await get_subscription_by_label(group_id, label)
+    if sub is None:
+        await refine_query.finish(f"未找到标签为「{label}」的订阅")
+        return
+
+    result = await get_latest_result(sub.id)
+    if result is None:
+        await refine_query.finish(
+            f"订阅 [{label}] 暂无结果。发送 `炼化刷新 {label}` 立即生成"
+        )
+        return
+
+    members: list[str] | None = None
+    if sub.target_type == "collection":
+        members = await _resolve_collection_members(group_id, sub.target_value)
+
+    await refine_query.finish(_format_result_block(sub, result, members))
+
+
+@refine_refresh.handle()
+async def _refresh(event: GroupMessageEvent, args: Message = CommandArg()) -> None:
+    label = args.extract_plain_text().strip()
+    if not label:
+        await refine_refresh.finish("用法：炼化刷新 <标签>")
+        return
+
+    group_id = str(event.group_id)
+    sub = await get_subscription_by_label(group_id, label)
+    if sub is None:
+        await refine_refresh.finish(f"未找到标签为「{label}」的订阅")
+        return
+
+    try:
+        _validate_ai_config(config)
+    except RefineConfigError as e:
+        await refine_refresh.finish(f"❌ AI 配置缺失：{e}")
+        return
+
+    await refine_refresh.send(f"⏳ 正在为 [{label}] 提炼，请稍候...")
+
+    outcome = await refine_single_subscription(sub, config)
+    if outcome.success:
+        result = await get_latest_result(sub.id)
+        if result is not None:
+            members: list[str] | None = None
+            if sub.target_type == "collection":
+                members = await _resolve_collection_members(group_id, sub.target_value)
+            await refine_refresh.finish(
+                _format_result_block(sub, result, members)
+            )
+            return
+        # pragma: no cover
+        await refine_refresh.finish(
+            f"✅ [{label}] 已提炼，但读回结果失败，请用 炼化查询 重试"
+        )
+        return
+
+    await refine_refresh.finish(
+        f"⚠️ [{label}] 提炼未完成：{outcome.error or '未知原因'}"
+    )
+
+
+@refine_help.handle()
+async def _help() -> None:
+    lines = [
+        "🧪 炼化插件帮助",
+        "",
+        "订阅某个用户或某集合的发言，每日定时由 AI 生成简要总结；",
+        "结果默认保留 3 天（可配置）。不主动推送，需手动查询。",
+        "",
+        "命令：",
+        "  炼化订阅 <标签> user:<qq>",
+        "  炼化订阅 <标签> collection:<名>",
+        "  炼化订阅 <标签> 集合 <名>",
+        "  炼化订阅 <标签> @某人",
+        "  炼化订阅列表",
+        "  炼化取消订阅 <标签>",
+        "  炼化查询 [标签]      # 不带标签则列出本群所有订阅的最新摘要",
+        "  炼化刷新 <标签>      # 立即重新提炼（覆盖最新结果）",
+    ]
+    await refine_help.finish("\n".join(lines))

--- a/src/plugins/refine/config.py
+++ b/src/plugins/refine/config.py
@@ -1,0 +1,97 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Config(BaseModel):
+    refine_plugin_enabled: bool = Field(
+        default=False,
+        description="是否启用炼化插件",
+    )
+
+    refine_group_mode: Literal["all", "whitelist", "blacklist"] = Field(
+        default="all",
+        description="群组控制模式: all(全部群启用) | whitelist(仅白名单群) | blacklist(黑名单外的群)",
+    )
+    refine_group_whitelist: list[str] = Field(
+        default=[],
+        description="白名单群组(仅在 whitelist 模式生效)",
+    )
+    refine_group_blacklist: list[str] = Field(
+        default=[],
+        description="黑名单群组(仅在 blacklist 模式生效)",
+    )
+
+    # ── AI 接口（OpenAI 兼容） ─────────────────────────
+    refine_ai_base_url: str = Field(
+        default="",
+        description="OpenAI 兼容接口的 Base URL（如 https://api.openai.com/v1）",
+    )
+    refine_ai_api_key: str = Field(
+        default="",
+        description="OpenAI 兼容接口的 API Key",
+    )
+    refine_ai_model: str = Field(
+        default="",
+        description="OpenAI 兼容接口的模型名称（如 gpt-4o-mini）",
+    )
+    refine_ai_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        le=120,
+        description="AI 请求超时时间（秒）",
+    )
+    refine_ai_temperature: float = Field(
+        default=0.3,
+        ge=0,
+        le=2,
+        description="AI 采样温度",
+    )
+
+    # ── 结果保留 ──────────────────────────────────────
+    refine_result_retention_days: int = Field(
+        default=3,
+        ge=1,
+        le=90,
+        description="炼化结果保留天数，超期自动清理",
+    )
+
+    # ── 调度 ──────────────────────────────────────────
+    refine_schedule_cron_hour: int = Field(
+        default=8,
+        ge=0,
+        le=23,
+        description="每日定时提炼的小时（0-23）。默认每天 08:00 跑一次。",
+    )
+    refine_schedule_cron_minute: int = Field(
+        default=0,
+        ge=0,
+        le=59,
+        description="每日定时提炼的分钟（0-59）",
+    )
+    refine_lookback_hours: int = Field(
+        default=24,
+        ge=1,
+        le=168,
+        description="每次提炼回看最近多少小时的发言（1-168，即最多 7 天）",
+    )
+
+    # ── Prompt 预算 ────────────────────────────────────
+    refine_max_messages_per_target: int = Field(
+        default=200,
+        ge=1,
+        le=2000,
+        description="单次提炼每个目标最多采样的消息条数",
+    )
+    refine_max_prompt_chars: int = Field(
+        default=12000,
+        ge=1000,
+        le=50000,
+        description="单次提炼 prompt 中拼接原文的字符预算",
+    )
+    refine_min_messages_to_refine: int = Field(
+        default=5,
+        ge=1,
+        le=500,
+        description="目标在回看窗口内少于该消息数时跳过提炼（避免无意义调用 AI）",
+    )

--- a/src/plugins/refine/db.py
+++ b/src/plugins/refine/db.py
@@ -1,0 +1,285 @@
+"""炼化插件持久层。
+
+- ``refine_subscription``: 一个群内对某个目标的订阅（单用户或 un_nickname 集合）
+- ``refine_result``: 周期生成的 AI 总结，绑定订阅；保留期由 scheduler 清理
+
+依赖 ``message_archive`` 表（由 ``src.plugins.message_archive.db.ensure_schema``
+创建）作为发言数据源；依赖 ``nickname_collections`` 表（由 ``un_nickname`` 创建）
+作为集合成员查询源。本插件 schema 只负责自己的两张表，跨插件只读不写。
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+from src.storage import get_db
+
+TargetType = Literal["user", "collection"]
+
+
+@dataclass(slots=True)
+class RefineSubscription:
+    id: int
+    group_id: str
+    target_type: TargetType
+    target_value: str
+    label: str
+    created_at: int
+
+
+@dataclass(slots=True)
+class RefineResult:
+    id: int
+    subscription_id: int
+    period_start: int
+    period_end: int
+    summary: str
+    message_count: int
+    model_name: str
+    created_at: int
+
+
+_SCHEMA_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS refine_subscription (
+        id           INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id     TEXT NOT NULL,
+        target_type  TEXT NOT NULL,
+        target_value TEXT NOT NULL,
+        label        TEXT NOT NULL,
+        created_at   INTEGER NOT NULL,
+        UNIQUE (group_id, target_type, target_value),
+        UNIQUE (group_id, label)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_refine_subscription_group
+    ON refine_subscription (group_id)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS refine_result (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        subscription_id INTEGER NOT NULL,
+        period_start    INTEGER NOT NULL,
+        period_end      INTEGER NOT NULL,
+        summary         TEXT NOT NULL,
+        message_count   INTEGER NOT NULL,
+        model_name      TEXT NOT NULL,
+        created_at      INTEGER NOT NULL,
+        FOREIGN KEY (subscription_id) REFERENCES refine_subscription(id) ON DELETE CASCADE
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_refine_result_sub_period
+    ON refine_result (subscription_id, period_end)
+    """,
+]
+
+
+def ensure_schema() -> None:
+    """确保炼化插件表结构存在。"""
+    db = get_db()
+    db.ensure_schema(_SCHEMA_STATEMENTS)
+
+
+# ── row 映射 ──────────────────────────────────────────
+
+
+def _row_to_subscription(row: sqlite3.Row) -> RefineSubscription:
+    return RefineSubscription(
+        id=row["id"],
+        group_id=row["group_id"],
+        target_type=row["target_type"],
+        target_value=row["target_value"],
+        label=row["label"],
+        created_at=row["created_at"],
+    )
+
+
+def _row_to_result(row: sqlite3.Row) -> RefineResult:
+    return RefineResult(
+        id=row["id"],
+        subscription_id=row["subscription_id"],
+        period_start=row["period_start"],
+        period_end=row["period_end"],
+        summary=row["summary"],
+        message_count=row["message_count"],
+        model_name=row["model_name"],
+        created_at=row["created_at"],
+    )
+
+
+# ── 订阅 CRUD ──────────────────────────────────────────
+
+
+async def add_subscription(
+    *,
+    group_id: str,
+    target_type: TargetType,
+    target_value: str,
+    label: str,
+) -> RefineSubscription | None:
+    """新增订阅。返回新对象；若 (group_id, target_type, target_value) 或 label
+    已存在则返回 None（由调用方区分两种冲突）。"""
+    db = get_db()
+    now = int(time.time())
+    try:
+        await db.execute(
+            """
+            INSERT INTO refine_subscription
+                (group_id, target_type, target_value, label, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (group_id, target_type, target_value, label, now),
+        )
+    except sqlite3.IntegrityError:
+        return None
+    row = await db.fetch_one(
+        "SELECT * FROM refine_subscription WHERE group_id = ? AND label = ?",
+        (group_id, label),
+    )
+    return _row_to_subscription(row) if row else None
+
+
+async def conflict_on_target(
+    group_id: str, target_type: TargetType, target_value: str
+) -> RefineSubscription | None:
+    """检查 (group_id, target_type, target_value) 是否已被订阅。返回占用项或 None。"""
+    db = get_db()
+    row = await db.fetch_one(
+        """
+        SELECT * FROM refine_subscription
+        WHERE group_id = ? AND target_type = ? AND target_value = ?
+        """,
+        (group_id, target_type, target_value),
+    )
+    return _row_to_subscription(row) if row else None
+
+
+async def conflict_on_label(group_id: str, label: str) -> RefineSubscription | None:
+    """检查 label 是否在该群已被使用。"""
+    db = get_db()
+    row = await db.fetch_one(
+        "SELECT * FROM refine_subscription WHERE group_id = ? AND label = ?",
+        (group_id, label),
+    )
+    return _row_to_subscription(row) if row else None
+
+
+async def list_subscriptions(group_id: str) -> list[RefineSubscription]:
+    db = get_db()
+    rows = await db.fetch_all(
+        """
+        SELECT * FROM refine_subscription
+        WHERE group_id = ?
+        ORDER BY created_at ASC
+        """,
+        (group_id,),
+    )
+    return [_row_to_subscription(r) for r in rows]
+
+
+async def get_subscription_by_label(
+    group_id: str, label: str
+) -> RefineSubscription | None:
+    db = get_db()
+    row = await db.fetch_one(
+        "SELECT * FROM refine_subscription WHERE group_id = ? AND label = ?",
+        (group_id, label),
+    )
+    return _row_to_subscription(row) if row else None
+
+
+async def delete_subscription(*, group_id: str, label: str) -> bool:
+    """删除订阅。ON DELETE CASCADE 会同时清理对应的 refine_result。"""
+    db = get_db()
+    existing = await get_subscription_by_label(group_id, label)
+    if existing is None:
+        return False
+    await db.execute(
+        "DELETE FROM refine_subscription WHERE id = ?",
+        (existing.id,),
+    )
+    return True
+
+
+async def list_all_subscriptions() -> list[RefineSubscription]:
+    """全量订阅（scheduler 用）。"""
+    db = get_db()
+    rows = await db.fetch_all(
+        "SELECT * FROM refine_subscription ORDER BY group_id, created_at ASC"
+    )
+    return [_row_to_subscription(r) for r in rows]
+
+
+# ── 结果 CRUD ──────────────────────────────────────────
+
+
+async def add_result(
+    *,
+    subscription_id: int,
+    period_start: int,
+    period_end: int,
+    summary: str,
+    message_count: int,
+    model_name: str,
+) -> RefineResult:
+    db = get_db()
+    now = int(time.time())
+    await db.execute(
+        """
+        INSERT INTO refine_result
+            (subscription_id, period_start, period_end, summary,
+             message_count, model_name, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (subscription_id, period_start, period_end, summary, message_count, model_name, now),
+    )
+    row = await db.fetch_one(
+        """
+        SELECT * FROM refine_result
+        WHERE subscription_id = ? AND created_at = ?
+        ORDER BY id DESC LIMIT 1
+        """,
+        (subscription_id, now),
+    )
+    if row is None:  # pragma: no cover  # 极端情况防御
+        raise RuntimeError("插入 refine_result 后无法读回")
+    return _row_to_result(row)
+
+
+async def get_latest_result(subscription_id: int) -> RefineResult | None:
+    db = get_db()
+    row = await db.fetch_one(
+        """
+        SELECT * FROM refine_result
+        WHERE subscription_id = ?
+        ORDER BY period_end DESC, id DESC
+        LIMIT 1
+        """,
+        (subscription_id,),
+    )
+    return _row_to_result(row) if row else None
+
+
+async def purge_expired_results(retention_days: int) -> int:
+    """清理创建时间早于 ``retention_days`` 天的结果。返回删除条数。"""
+    if retention_days <= 0:
+        return 0
+    db = get_db()
+    cutoff = int(time.time()) - retention_days * 86400
+    row = await db.fetch_one(
+        "SELECT COUNT(*) AS c FROM refine_result WHERE created_at < ?",
+        (cutoff,),
+    )
+    before = row["c"] if row else 0
+    if before == 0:
+        return 0
+    await db.execute(
+        "DELETE FROM refine_result WHERE created_at < ?",
+        (cutoff,),
+    )
+    return before

--- a/src/plugins/refine/exceptions.py
+++ b/src/plugins/refine/exceptions.py
@@ -1,0 +1,42 @@
+"""炼化插件错误类型层级。
+
+参考 ``a_share_sentiment.ai`` 与 ``trawler.exceptions`` 的设计：基类
+``RefineError`` 统一所有可恢复错误；commands 层用 ``friendly_error`` 把
+各子类映射为用户可见的中文提示。
+"""
+
+
+class RefineError(Exception):
+    """炼化功能可恢复错误基类。"""
+
+
+class RefineAIError(RefineError):
+    """AI 分析失败基类。"""
+
+
+class RefineAITimeoutError(RefineAIError):
+    """AI 请求超时。"""
+
+
+class RefineAIAuthError(RefineAIError):
+    """AI 鉴权失败。"""
+
+
+class RefineAIServiceError(RefineAIError):
+    """AI 服务异常（HTTP 5xx / 网络错误）。"""
+
+
+class RefineAIResponseError(RefineAIError):
+    """AI 返回格式异常（空响应 / 不是合法 JSON / 缺字段）。"""
+
+
+class RefineConfigError(RefineError):
+    """配置缺失或不合法（缺 api_key / base_url / model 等）。"""
+
+
+class RefineSubscriptionNotFoundError(RefineError):
+    """订阅不存在。"""
+
+
+class RefineCollectionNotFoundError(RefineError):
+    """引用的 un_nickname 集合不存在。"""

--- a/src/plugins/refine/runner.py
+++ b/src/plugins/refine/runner.py
@@ -1,0 +1,149 @@
+"""炼化调度核心：周期遍历订阅 → 采集 → AI 提炼 → 落库；以及过期结果清理。
+
+设计要点:
+- 调度器 **只写库不推送**。用户必须用 `炼化查询` 命令手动拉结果（需求明确）。
+- 单次失败只 warning 不抛，不影响其他订阅。
+- ``refine_subscription`` 引用的 un_nickname 集合可能已被删（成员空），此时
+  采集为空 → 跳过 AI 调用，记录 info 而非失败。
+- 过期清理独立 cron，每日凌晨执行。
+
+文件命名为 ``runner.py``（非 ``scheduler.py``）以避免与 apscheduler 注入的
+``scheduler`` 变量在 pyright 中产生命名空间歧义。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from nonebot import logger
+
+from .ai import request_refine_summary
+from .collector import collect_and_build_payload
+from .db import (
+    RefineSubscription,
+    add_result,
+    list_all_subscriptions,
+    purge_expired_results,
+)
+from .exceptions import RefineAIError, RefineConfigError
+
+if TYPE_CHECKING:
+    from .config import Config
+
+
+@dataclass(slots=True)
+class RefineRunOutcome:
+    """单次提炼结果摘要（用于日志与即时刷新命令回执）。"""
+
+    subscription_id: int
+    success: bool
+    message_count: int
+    error: str | None = None
+    summary_preview: str | None = None
+
+
+def _validate_ai_config(config: Config) -> None:
+    if not config.refine_ai_base_url.strip():
+        raise RefineConfigError("refine_ai_base_url 未配置")
+    if not config.refine_ai_api_key.strip():
+        raise RefineConfigError("refine_ai_api_key 未配置")
+    if not config.refine_ai_model.strip():
+        raise RefineConfigError("refine_ai_model 未配置")
+
+
+async def refine_single_subscription(
+    sub: RefineSubscription,
+    config: Config,
+) -> RefineRunOutcome:
+    """对单个订阅跑一次采集 + AI + 落库。"""
+    try:
+        _validate_ai_config(config)
+    except RefineConfigError as e:
+        return RefineRunOutcome(
+            subscription_id=sub.id, success=False, message_count=0, error=str(e)
+        )
+
+    collected, payload = await collect_and_build_payload(sub, config)
+
+    if len(collected.messages) < config.refine_min_messages_to_refine:
+        logger.info(
+            f"[炼化] 订阅 {sub.label} (group={sub.group_id}) "
+            f"窗口内仅 {len(collected.messages)} 条消息，不足 "
+            f"{config.refine_min_messages_to_refine}，跳过"
+        )
+        return RefineRunOutcome(
+            subscription_id=sub.id,
+            success=False,
+            message_count=len(collected.messages),
+            error="消息不足，跳过",
+        )
+
+    try:
+        summary = await request_refine_summary(
+            base_url=config.refine_ai_base_url.strip(),
+            api_key=config.refine_ai_api_key.strip(),
+            model=config.refine_ai_model.strip(),
+            timeout_seconds=config.refine_ai_timeout_seconds,
+            temperature=config.refine_ai_temperature,
+            prompt_payload=payload,
+        )
+    except RefineAIError as e:
+        logger.warning(f"[炼化] 订阅 {sub.label} AI 失败: {e}")
+        return RefineRunOutcome(
+            subscription_id=sub.id,
+            success=False,
+            message_count=len(collected.messages),
+            error=str(e),
+        )
+
+    await add_result(
+        subscription_id=sub.id,
+        period_start=collected.period_start,
+        period_end=collected.period_end,
+        summary=summary,
+        message_count=len(collected.messages),
+        model_name=config.refine_ai_model.strip(),
+    )
+    logger.info(
+        f"[炼化] 订阅 {sub.label} 提炼成功 ({len(collected.messages)} 条消息)"
+    )
+    return RefineRunOutcome(
+        subscription_id=sub.id,
+        success=True,
+        message_count=len(collected.messages),
+        summary_preview=summary[:80],
+    )
+
+
+async def run_daily_refine(config: Config) -> list[RefineRunOutcome]:
+    """遍历全部订阅跑一次。供 cron 与 `炼化刷新` 命令共用。"""
+    subs = await list_all_subscriptions()
+    outcomes: list[RefineRunOutcome] = []
+    for sub in subs:
+        try:
+            outcome = await refine_single_subscription(sub, config)
+        except Exception as e:
+            logger.exception(f"[炼化] 订阅 {sub.label} 异常")
+            outcomes.append(
+                RefineRunOutcome(
+                    subscription_id=sub.id,
+                    success=False,
+                    message_count=0,
+                    error=f"未知异常: {e}",
+                )
+            )
+            continue
+        outcomes.append(outcome)
+    return outcomes
+
+
+async def run_purge(config: Config) -> int:
+    """清理过期结果。返回清理条数。"""
+    deleted = await purge_expired_results(config.refine_result_retention_days)
+    if deleted:
+        logger.info(
+            f"[炼化] 清理 {deleted} 条过期结果 "
+            f"(> {config.refine_result_retention_days} 天)"
+        )
+    return deleted

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,18 @@ async def load_plugins(_nonebot_init: None):
     load_plugin("src.plugins.message_archive")
     load_plugin("src.plugins.chat_forward")
     load_plugin("src.plugins.a_share_sentiment")
+    load_plugin("src.plugins.un_nickname")
+    load_plugin("src.plugins.refine")
 
     from src.plugins.message_archive.db import ensure_schema
+    from src.plugins.refine.db import ensure_schema as ensure_refine_schema
+    from src.plugins.un_nickname.db import (
+        ensure_schema as ensure_un_nickname_schema,
+    )
 
     ensure_schema()
+    ensure_refine_schema()
+    ensure_un_nickname_schema()
 
 
 @pytest.fixture(autouse=True)
@@ -65,11 +73,21 @@ def reset_a_share_sentiment_state() -> None:
 async def reset_message_archive_table() -> None:
     """每个用例前清空消息归档表。"""
     from src.plugins.message_archive.db import ensure_schema
+    from src.plugins.refine.db import ensure_schema as ensure_refine_schema
+    from src.plugins.un_nickname.db import (
+        ensure_schema as ensure_un_nickname_schema,
+    )
     from src.storage import get_db
 
     ensure_schema()
+    ensure_refine_schema()
+    ensure_un_nickname_schema()
     await get_db().execute("DELETE FROM message_archive")
     await get_db().execute("DELETE FROM message_archive_image")
+    await get_db().execute("DELETE FROM refine_result")
+    await get_db().execute("DELETE FROM refine_subscription")
+    await get_db().execute("DELETE FROM nicknames")
+    await get_db().execute("DELETE FROM nickname_collections")
 
 
 @pytest_asyncio.fixture

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -1,0 +1,761 @@
+"""炼化插件测试。
+
+覆盖:
+- DB schema + CRUD（订阅 / 结果 / 清理 + cascade）
+- collector（采集 + 目标解析 + prompt 截断）
+- ai 错误分类（timeout / 401 / 5xx / 格式错）
+- commands 端到端（订阅 / 查询 / 刷新 / 取消，使用 nonebug 标准模式）
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from nonebot.adapters.onebot.v11 import (
+    Bot,
+    GroupMessageEvent,
+    Message,
+    MessageSegment,
+)
+from nonebot.adapters.onebot.v11.event import Sender
+from nonebug import App
+
+# ── 事件工厂 ────────────────────────────────────────────
+
+
+def make_group_event(
+    message: Message | str,
+    *,
+    message_id: int = 1,
+    user_id: int = 100001,
+    group_id: int = 200001,
+    self_id: int = 987654321,
+    nickname: str = "测试用户",
+    card: str = "",
+    event_time: int | None = None,
+) -> GroupMessageEvent:
+    actual = message if isinstance(message, Message) else Message(message)
+    return GroupMessageEvent(
+        time=event_time or int(datetime.now().timestamp()),
+        self_id=self_id,
+        post_type="message",
+        sub_type="normal",
+        user_id=user_id,
+        message_type="group",
+        group_id=group_id,
+        message_id=message_id,
+        message=actual,
+        original_message=actual.copy(),
+        raw_message=str(actual),
+        font=0,
+        sender=Sender(user_id=user_id, nickname=nickname, card=card, role="member"),
+    )
+
+
+def configure_refine_plugin(**overrides: object) -> None:
+    """在已加载的插件 config 实例上打补丁。"""
+    import src.plugins.refine as rp
+
+    for key, value in overrides.items():
+        setattr(rp.config, key, value)
+
+
+def _fake_ai_response(content: str = "AI 生成的总结") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "choices": [
+                {"message": {"role": "assistant", "content": content}},
+            ],
+        },
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+
+
+def expect_bot_not_muted(
+    ctx, group_id: int = 200001, self_id: int = 987654321
+) -> None:
+    """should_call_send 之前必须先声明：bot 不被禁言。
+
+    项目 ``check_group_permission`` 在群消息场景下会查 mute cache，触发
+    get_group_member_info API。未先声明会导致 nonebug 报意外 API 调用。
+    """
+    ctx.should_call_api(
+        "get_group_member_info",
+        {"group_id": group_id, "user_id": self_id, "no_cache": True},
+        result={"shut_up_timestamp": 0},
+    )
+
+
+# ── 公共 fixture ────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def reset_refine_config() -> None:
+    configure_refine_plugin(
+        refine_plugin_enabled=True,
+        refine_group_mode="all",
+        refine_group_whitelist=[],
+        refine_group_blacklist=[],
+        refine_ai_base_url="https://example.com/v1",
+        refine_ai_api_key="sk-test",
+        refine_ai_model="gpt-test",
+        refine_ai_timeout_seconds=30.0,
+        refine_ai_temperature=0.3,
+        refine_result_retention_days=3,
+        refine_lookback_hours=24,
+        refine_max_messages_per_target=200,
+        refine_max_prompt_chars=12000,
+        refine_min_messages_to_refine=2,
+    )
+
+
+# ── DB 测试 ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_subscription_crud() -> None:
+    from src.plugins.refine.db import (
+        add_subscription,
+        conflict_on_label,
+        conflict_on_target,
+        delete_subscription,
+        get_subscription_by_label,
+        list_subscriptions,
+    )
+
+    sub = await add_subscription(
+        group_id="g1", target_type="user", target_value="u1", label="张三"
+    )
+    assert sub is not None
+    assert sub.label == "张三"
+
+    assert await conflict_on_label("g1", "张三") is not None
+    assert await conflict_on_target("g1", "user", "u1") is not None
+    again = await add_subscription(
+        group_id="g1", target_type="user", target_value="u1", label="别名"
+    )
+    assert again is None
+
+    assert len(await list_subscriptions("g1")) == 1
+    assert await get_subscription_by_label("g1", "张三") is not None
+    assert await get_subscription_by_label("g1", "不存在") is None
+
+    assert await delete_subscription(group_id="g1", label="张三") is True
+    assert await delete_subscription(group_id="g1", label="张三") is False
+    assert len(await list_subscriptions("g1")) == 0
+
+
+@pytest.mark.asyncio
+async def test_db_result_purge() -> None:
+    from src.plugins.refine.db import (
+        add_result,
+        add_subscription,
+        get_latest_result,
+        purge_expired_results,
+    )
+    from src.storage import get_db
+
+    sub = await add_subscription(
+        group_id="g1", target_type="user", target_value="u1", label="张三"
+    )
+    assert sub is not None
+
+    now = int(time.time())
+    new = await add_result(
+        subscription_id=sub.id,
+        period_start=now - 3600,
+        period_end=now,
+        summary="新总结",
+        message_count=10,
+        model_name="gpt-test",
+    )
+    old = await add_result(
+        subscription_id=sub.id,
+        period_start=now - 86400 * 30,
+        period_end=now - 86400 * 30 + 3600,
+        summary="远古总结",
+        message_count=5,
+        model_name="gpt-test",
+    )
+
+    latest = await get_latest_result(sub.id)
+    assert latest is not None
+    assert latest.summary == "新总结"
+
+    # 篡改 old 的 created_at 到 10 天前，触发清理（new 保持当下）
+    await get_db().execute(
+        "UPDATE refine_result SET created_at = ? WHERE id = ?",
+        (now - 86400 * 10, old.id),
+    )
+    deleted = await purge_expired_results(retention_days=3)
+    assert deleted == 1
+    remaining = await get_latest_result(sub.id)
+    assert remaining is not None
+    assert remaining.id == new.id
+
+
+@pytest.mark.asyncio
+async def test_db_delete_subscription_cascades_results() -> None:
+    from src.plugins.refine.db import (
+        add_result,
+        add_subscription,
+        delete_subscription,
+        get_latest_result,
+    )
+
+    sub = await add_subscription(
+        group_id="g1", target_type="user", target_value="u1", label="张三"
+    )
+    assert sub is not None
+    now = int(time.time())
+    await add_result(
+        subscription_id=sub.id,
+        period_start=now - 3600,
+        period_end=now,
+        summary="x",
+        message_count=1,
+        model_name="m",
+    )
+    assert await get_latest_result(sub.id) is not None
+
+    assert await delete_subscription(group_id="g1", label="张三") is True
+    assert await get_latest_result(sub.id) is None
+
+
+# ── collector 测试 ─────────────────────────────────────
+
+
+def test_resolve_target_variants() -> None:
+    from src.plugins.refine.collector import resolve_target_type_and_value
+
+    assert resolve_target_type_and_value("user:123456") == ("user", "123456")
+    assert resolve_target_type_and_value("123456") == ("user", "123456")
+    assert resolve_target_type_and_value("collection:核心") == ("collection", "核心")
+    assert resolve_target_type_and_value("集合 核心") == ("collection", "核心")
+    assert resolve_target_type_and_value("集合核心") == ("collection", "核心")
+    assert resolve_target_type_and_value("") == (None, None)
+    assert resolve_target_type_and_value("未知") == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_collect_filters_by_user_and_window() -> None:
+    from src.plugins.message_archive.db import archive_message_event
+    from src.plugins.refine.collector import collect_messages_for_subscription
+    from src.plugins.refine.db import RefineSubscription
+
+    now = int(time.time())
+    await archive_message_event(
+        make_group_event(
+            "目标发言A",
+            user_id=111,
+            group_id=222,
+            message_id=1,
+            event_time=now - 600,
+            nickname="目标",
+        )
+    )
+    await archive_message_event(
+        make_group_event(
+            "目标发言B",
+            user_id=111,
+            group_id=222,
+            message_id=2,
+            event_time=now - 300,
+            nickname="目标",
+        )
+    )
+    await archive_message_event(
+        make_group_event(
+            "他人发言", user_id=999, group_id=222, message_id=3, event_time=now - 100
+        )
+    )
+    await archive_message_event(
+        make_group_event(
+            "远古发言",
+            user_id=111,
+            group_id=222,
+            message_id=4,
+            event_time=now - 86400 * 5,
+        )
+    )
+
+    sub = RefineSubscription(
+        id=1,
+        group_id="222",
+        target_type="user",
+        target_value="111",
+        label="目标",
+        created_at=now,
+    )
+    collected = await collect_messages_for_subscription(
+        sub, lookback_hours=24, max_messages=100, max_prompt_chars=10000
+    )
+    texts = [t for _, _, t in collected.messages]
+    assert "目标发言A" in texts
+    assert "目标发言B" in texts
+    assert "他人发言" not in texts
+    assert "远古发言" not in texts
+
+
+@pytest.mark.asyncio
+async def test_collect_handles_empty_collection_target() -> None:
+    from src.plugins.refine.collector import collect_messages_for_subscription
+    from src.plugins.refine.db import RefineSubscription
+
+    now = int(time.time())
+    sub = RefineSubscription(
+        id=1,
+        group_id="222",
+        target_type="collection",
+        target_value="不存在的集合",
+        label="x",
+        created_at=now,
+    )
+    collected = await collect_messages_for_subscription(
+        sub, lookback_hours=24, max_messages=100, max_prompt_chars=10000
+    )
+    assert collected.messages == []
+
+
+def test_build_prompt_payload_truncates() -> None:
+    from src.plugins.refine.collector import (
+        CollectedMessages,
+        build_prompt_payload,
+    )
+
+    collected = CollectedMessages(
+        messages=[
+            (1700000000, "Alice", "x" * 50),
+            (1700000100, "Bob", "y" * 50),
+        ],
+        period_start=1700000000,
+        period_end=1700000100,
+    )
+    out = build_prompt_payload(collected, max_prompt_chars=80)
+    assert len(out) <= 80
+
+
+# ── AI 测试 ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ai_success() -> None:
+    from src.plugins.refine.ai import request_refine_summary
+
+    with patch(
+        "httpx.AsyncClient.post",
+        new=AsyncMock(return_value=_fake_ai_response("hello world")),
+    ):
+        result = await request_refine_summary(
+            base_url="https://example.com/v1",
+            api_key="sk-test",
+            model="gpt-test",
+            timeout_seconds=10,
+            temperature=0.3,
+            prompt_payload="xxx",
+        )
+    assert result == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_ai_timeout_classified() -> None:
+    from src.plugins.refine.ai import request_refine_summary
+    from src.plugins.refine.exceptions import RefineAITimeoutError
+
+    with patch(
+        "httpx.AsyncClient.post",
+        new=AsyncMock(side_effect=httpx.ReadTimeout("t")),
+    ), pytest.raises(RefineAITimeoutError):
+        await request_refine_summary(
+            base_url="https://example.com/v1",
+            api_key="sk-test",
+            model="gpt-test",
+            timeout_seconds=10,
+            temperature=0.3,
+            prompt_payload="xxx",
+        )
+
+
+@pytest.mark.asyncio
+async def test_ai_auth_error_classified() -> None:
+    from src.plugins.refine.ai import request_refine_summary
+    from src.plugins.refine.exceptions import RefineAIAuthError
+
+    response = httpx.Response(
+        401,
+        json={"error": "bad key"},
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=response)):
+        with pytest.raises(RefineAIAuthError):
+            await request_refine_summary(
+                base_url="https://example.com/v1",
+                api_key="sk-bad",
+                model="gpt-test",
+                timeout_seconds=10,
+                temperature=0.3,
+                prompt_payload="xxx",
+            )
+
+
+@pytest.mark.asyncio
+async def test_ai_response_format_error() -> None:
+    from src.plugins.refine.ai import request_refine_summary
+    from src.plugins.refine.exceptions import RefineAIResponseError
+
+    response = httpx.Response(
+        200,
+        json={"foo": "bar"},
+        request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+    )
+    with patch("httpx.AsyncClient.post", new=AsyncMock(return_value=response)):
+        with pytest.raises(RefineAIResponseError):
+            await request_refine_summary(
+                base_url="https://example.com/v1",
+                api_key="sk-test",
+                model="gpt-test",
+                timeout_seconds=10,
+                temperature=0.3,
+                prompt_payload="xxx",
+            )
+
+
+# ── commands 端到端（nonebug 标准模式） ────────────────
+
+
+@pytest.mark.asyncio
+async def test_command_subscribe_user(app: App) -> None:
+    from src.plugins.refine import commands
+
+    event = make_group_event(
+        "炼化订阅 张三 user:111", message_id=10, group_id=200001
+    )
+    async with app.test_matcher(commands.refine_subscribe) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            (
+                "✅ 已订阅 [张三] (用户=111)\n"
+                "下次定时提炼：每日 08:00\n"
+                "若需立即生成结果，发送：炼化刷新 张三"
+            ),
+            result={"message_id": 1000},
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_subscribe_with_at(app: App) -> None:
+    from src.plugins.refine import commands
+
+    msg = Message("炼化订阅 目标A") + Message(MessageSegment.at(555))
+    event = GroupMessageEvent(
+        time=int(datetime.now().timestamp()),
+        self_id=987654321,
+        post_type="message",
+        sub_type="normal",
+        user_id=100001,
+        message_type="group",
+        group_id=200001,
+        message_id=11,
+        message=msg,
+        original_message=msg.copy(),
+        raw_message=str(msg),
+        font=0,
+        sender=Sender(user_id=100001, nickname="测试", card="", role="member"),
+    )
+    async with app.test_matcher(commands.refine_subscribe) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            (
+                "✅ 已订阅 [目标A] (用户=555)\n"
+                "下次定时提炼：每日 08:00\n"
+                "若需立即生成结果，发送：炼化刷新 目标A"
+            ),
+            result={"message_id": 1001},
+        )
+
+    from src.plugins.refine.db import get_subscription_by_label
+
+    sub = await get_subscription_by_label("200001", "目标A")
+    assert sub is not None
+    assert sub.target_type == "user"
+    assert sub.target_value == "555"
+
+
+@pytest.mark.asyncio
+async def test_command_subscribe_collection_not_exists(app: App) -> None:
+    from src.plugins.refine import commands
+
+    event = make_group_event(
+        "炼化订阅 团队 collection:不存在的集合", message_id=12
+    )
+    async with app.test_matcher(commands.refine_subscribe) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            "集合「不存在的集合」不存在或无成员。请先用 un_nickname 插件的 `集合 <名> @人` 命令创建。",
+            result={"message_id": 1002},
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_query_returns_no_result_message(app: App) -> None:
+    from src.plugins.refine import commands
+    from src.plugins.refine.db import add_subscription
+
+    await add_subscription(
+        group_id="200001", target_type="user", target_value="111", label="张三"
+    )
+    event = make_group_event("炼化查询 张三", message_id=14)
+    async with app.test_matcher(commands.refine_query) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            "订阅 [张三] 暂无结果。发送 `炼化刷新 张三` 立即生成",
+            result={"message_id": 1003},
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_query_returns_latest_result(app: App) -> None:
+    """query handler 的端到端测试因动态时间戳难以精确断言整段字符串，
+    用 patch.object(commands, "datetime") 固定 strftime 输出。
+    """
+    from src.plugins.refine import commands
+    from src.plugins.refine.db import add_result, add_subscription
+
+    sub = await add_subscription(
+        group_id="200001", target_type="user", target_value="111", label="张三"
+    )
+    assert sub is not None
+    fixed_now = 1_800_000_000
+    await add_result(
+        subscription_id=sub.id,
+        period_start=fixed_now - 3600,
+        period_end=fixed_now,
+        summary="预先存好的总结",
+        message_count=10,
+        model_name="gpt-test",
+    )
+
+    fake_dt = type("FakeDT", (), {"strftime": lambda self, fmt: "T"})()
+    event = make_group_event("炼化查询 张三", message_id=15)
+
+    with patch.object(commands, "datetime") as mock_dt:
+        mock_dt.fromtimestamp.return_value = fake_dt
+        async with app.test_matcher(commands.refine_query) as ctx:
+            bot = ctx.create_bot(base=Bot, self_id="987654321")
+            expect_bot_not_muted(ctx)
+            ctx.receive_event(bot, event)
+            ctx.should_pass_rule()
+            ctx.should_call_send(
+                event,
+                (
+                    "🧪 炼化结果：[张三]\n"
+                    "目标：用户=111\n"
+                    "采样窗口：T ~ T\n"
+                    "采样消息：10 条\n"
+                    "模型：gpt-test\n"
+                    "\n"
+                    "预先存好的总结"
+                ),
+                result={"message_id": 1004},
+            )
+
+
+@pytest.mark.asyncio
+async def test_command_refresh_insufficient_messages(app: App) -> None:
+    """刷新时窗口内目标无消息，应给出跳过提示。"""
+    from src.plugins.refine import commands
+    from src.plugins.refine.db import add_subscription
+
+    await add_subscription(
+        group_id="200001", target_type="user", target_value="111", label="张三"
+    )
+    event = make_group_event("炼化刷新 张三", message_id=16)
+    async with app.test_matcher(commands.refine_refresh) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event, "⏳ 正在为 [张三] 提炼，请稍候...", result={"message_id": 1005}
+        )
+        ctx.should_call_send(
+            event,
+            "⚠️ [张三] 提炼未完成：消息不足，跳过",
+            result={"message_id": 1006},
+        )
+
+
+@pytest.mark.asyncio
+async def test_command_refresh_success(app: App) -> None:
+    """刷新成功应落库并返回总结。"""
+    from src.plugins.message_archive.db import archive_message_event
+    from src.plugins.refine import commands
+    from src.plugins.refine.db import (
+        add_subscription,
+        get_latest_result,
+        get_subscription_by_label,
+    )
+
+    fixed_now = 1_800_000_000
+    for i in range(3):
+        await archive_message_event(
+            make_group_event(
+                f"目标发言内容{i}",
+                user_id=111,
+                group_id=200001,
+                message_id=100 + i,
+                event_time=fixed_now - 600 + i * 60,
+                nickname="目标",
+            )
+        )
+
+    await add_subscription(
+        group_id="200001", target_type="user", target_value="111", label="张三"
+    )
+
+    event = make_group_event("炼化刷新 张三", message_id=17, event_time=fixed_now)
+    fake_dt = type("FakeDT", (), {"strftime": lambda self, fmt: "T"})()
+    with (
+        patch(
+            "httpx.AsyncClient.post",
+            new=AsyncMock(return_value=_fake_ai_response("AI 总结结果")),
+        ),
+        patch.object(commands, "datetime") as mock_dt,
+        patch("src.plugins.refine.collector.time.time", return_value=fixed_now),
+    ):
+        mock_dt.fromtimestamp.return_value = fake_dt
+        async with app.test_matcher(commands.refine_refresh) as ctx:
+            bot = ctx.create_bot(base=Bot, self_id="987654321")
+            expect_bot_not_muted(ctx)
+            ctx.receive_event(bot, event)
+            ctx.should_pass_rule()
+            ctx.should_call_send(
+                event,
+                "⏳ 正在为 [张三] 提炼，请稍候...",
+                result={"message_id": 1007},
+            )
+            ctx.should_call_send(
+                event,
+                (
+                    "🧪 炼化结果：[张三]\n"
+                    "目标：用户=111\n"
+                    "采样窗口：T ~ T\n"
+                    "采样消息：3 条\n"
+                    "模型：gpt-test\n"
+                    "\n"
+                    "AI 总结结果"
+                ),
+                result={"message_id": 1008},
+            )
+
+    sub = await get_subscription_by_label("200001", "张三")
+    assert sub is not None
+    result = await get_latest_result(sub.id)
+    assert result is not None
+    assert result.summary == "AI 总结结果"
+    assert result.message_count == 3
+
+
+@pytest.mark.asyncio
+async def test_command_unsubscribe(app: App) -> None:
+    from src.plugins.refine import commands
+    from src.plugins.refine.db import (
+        add_subscription,
+        get_subscription_by_label,
+    )
+
+    await add_subscription(
+        group_id="200001", target_type="user", target_value="111", label="张三"
+    )
+    event = make_group_event("炼化取消订阅 张三", message_id=18)
+    async with app.test_matcher(commands.refine_unsubscribe) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            "✅ 已取消订阅 [张三]，历史结果一并删除",
+            result={"message_id": 1009},
+        )
+
+    assert await get_subscription_by_label("200001", "张三") is None
+
+
+@pytest.mark.asyncio
+async def test_command_list_empty(app: App) -> None:
+    from src.plugins.refine import commands
+
+    event = make_group_event("炼化订阅列表", message_id=19)
+    async with app.test_matcher(commands.refine_list) as ctx:
+        bot = ctx.create_bot(base=Bot, self_id="987654321")
+        expect_bot_not_muted(ctx)
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_call_send(
+            event,
+            "本群暂无炼化订阅。发送 `炼化订阅 <标签> @某人` 添加",
+            result={"message_id": 1010},
+        )
+
+
+# ── runner 单元测试（不依赖 commands） ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_skips_when_messages_insufficient() -> None:
+    from src.plugins.refine.config import Config
+    from src.plugins.refine.db import add_subscription
+    from src.plugins.refine.runner import refine_single_subscription
+
+    sub = await add_subscription(
+        group_id="999", target_type="user", target_value="111", label="x"
+    )
+    assert sub is not None
+    cfg = Config(
+        refine_plugin_enabled=True,
+        refine_ai_base_url="https://example.com/v1",
+        refine_ai_api_key="sk-test",
+        refine_ai_model="gpt-test",
+        refine_min_messages_to_refine=100,
+    )
+    outcome = await refine_single_subscription(sub, cfg)
+    assert not outcome.success
+    assert "消息不足" in (outcome.error or "")
+
+
+@pytest.mark.asyncio
+async def test_runner_missing_ai_config() -> None:
+    from src.plugins.refine.config import Config
+    from src.plugins.refine.db import add_subscription
+    from src.plugins.refine.runner import refine_single_subscription
+
+    sub = await add_subscription(
+        group_id="999", target_type="user", target_value="111", label="x"
+    )
+    assert sub is not None
+    cfg = Config(refine_plugin_enabled=True)  # 缺 ai_*
+    outcome = await refine_single_subscription(sub, cfg)
+    assert not outcome.success
+    assert "未配置" in (outcome.error or "")


### PR DESCRIPTION
## 功能

新增「炼化」插件：订阅群聊发言人或 un_nickname 集合，按 cron 周期性通过 AI 提炼目标近期发言，生成简要总结，落库保留 N 天（默认 3）。**不主动推送**，用户必须用 `炼化查询` 命令手动拉取结果。

## 模块结构

```
src/plugins/refine/
  __init__.py     插件元数据 + 启动钩子 + cron 注册
  config.py       配置（AI url/key/model、保留天数、cron、群权限）
  exceptions.py   错误类型层级
  db.py           schema + 订阅/结果 CRUD（含 ON DELETE CASCADE）
  ai.py           OpenAI 兼容 chat/completions 调用
  collector.py    从 message_archive 取目标发言 + prompt 组装
  runner.py       周期任务 + 过期清理
  commands.py     6 个命令 handler
  README.md
```

## 命令清单

| 命令 | 说明 |
|---|---|
| `炼化订阅 <标签> user:<qq>` | 订阅单用户（也支持 `集合 <名>` / `collection:<名>` / @某人） |
| `炼化订阅列表` | 列出本群订阅 |
| `炼化取消订阅 <标签>` | 删除订阅（级联删除历史结果） |
| `炼化查询 [标签]` | 不带标签列出本群所有最新摘要；带标签返回完整结果 |
| `炼化刷新 <标签>` | 立即重新提炼（不等 cron，覆盖最新结果） |
| `炼化帮助` | 帮助 |

## 配置

```dotenv
REFINE_PLUGIN_ENABLED=true
REFINE_AI_BASE_URL=https://api.openai.com/v1
REFINE_AI_API_KEY=sk-xxx
REFINE_AI_MODEL=gpt-4o-mini
REFINE_RESULT_RETENTION_DAYS=3       # 默认 3 天
REFINE_SCHEDULE_CRON_HOUR=8          # 每日 08:00 跑
REFINE_LOOKBACK_HOURS=24
```

详见 `src/plugins/refine/README.md`。

## 设计要点

1. **懒触发**：scheduler 只写库不推送；用户必须 `炼化查询` 才收到结果（需求明确）
2. **复用数据源**：直接读 `message_archive` 表，不重复存储原始消息
3. **集合订阅**：复用 `un_nickname` 的 `nickname_collections` 表，不重复实现
4. **跳过 AI 调用**：消息不足阈值（默认 5）时跳过，节省 token
5. **清理独立**：每日 04:30 清理过期结果（按 created_at + retention_days）
6. **错误隔离**：单订阅失败不影响其他订阅

## 依赖

- `message_archive` — 发言原文（按时间窗 + 群号查询）
- `un_nickname` — 集合成员（订阅类型 collection 时使用）

两者均为内置插件，无需额外安装。

## 验证

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest tests/test_refine.py` — 22 passed
- [x] `uv run pytest` — 100 passed（5 个 sentiment 失败在 main 分支已存在，与本 PR 无关）

## 测试覆盖

22 个测试覆盖：
- DB schema + CRUD（订阅冲突检测、结果清理、级联删除）
- collector（按 user/时间窗过滤、集合不存在容错、prompt 截断）
- AI 错误分类（timeout / 401 / 5xx / 格式错）
- 命令端到端（订阅 / 列表 / 查询 / 刷新成功 / 刷新消息不足 / 取消）
- runner（配置缺失校验、消息不足跳过）

## 联调测试说明

**未做真实联调**。已验证范围仅限 nonebug 单元/集成测试级别（含 mock httpx/time/datetime）。
未覆盖：真实 NoneBot 启动、真实协议端、真实 AI 接口调用、真实 cron 触发、
un_nickname 集合订阅的完整采集链路、apscheduler 在 startup hook 内动态注册的实际行为。