### PR TITLE
feat(word-pulse): 群聊主题词频统计插件

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -179,3 +179,33 @@ NICKNAME=[""]
 # ========== 昵称 插件配置 ==========
 # 最大昵称长度，默认15
 # max_nickname_length=15
+
+
+# ========== Word Pulse 词频统计插件配置 ==========
+# 命令：词频 add/append/list/del/refresh, 总结 N天/周/月 主题
+
+# 插件全局开关，默认false
+# word_pulse_plugin_enabled=false
+
+# 分群配置
+# word_pulse_group_mode=all
+# word_pulse_group_whitelist=[]
+# word_pulse_group_blacklist=[]
+
+# AI 接口配置（OpenAI 兼容）
+# word_pulse_base_url=https://api.openai.com/v1
+# word_pulse_api_key=sk-xxxx
+# word_pulse_model=gpt-4.1-mini
+
+# 请求配置
+# word_pulse_timeout_seconds=60
+# word_pulse_temperature=0.0
+# word_pulse_summary_temperature=0.3
+
+# 成本控制
+# word_pulse_cooldown_seconds=30
+# word_pulse_cache_ttl_minutes=5
+# word_pulse_bucket_retention_days=30
+# word_pulse_max_messages_per_bucket=1000
+# word_pulse_max_window_days=31
+# word_pulse_today_bucket_fresh_seconds=300

--- a/src/plugins/word_pulse/__init__.py
+++ b/src/plugins/word_pulse/__init__.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from nonebot import get_driver, get_plugin_config, logger, on_regex, require
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageEvent
+from nonebot.exception import MatcherException
+from nonebot.plugin import PluginMetadata
+
+from src.plugins.group_permission import create_group_rule
+
+from .ai import (
+    WordPulseAIAuthError,
+    WordPulseAIError,
+    WordPulseAIResponseError,
+    WordPulseAIServiceError,
+    WordPulseAITimeoutError,
+    expand_charsets,
+    summarize,
+)
+from .analysis import build_summary_prompt, compute_or_load_buckets
+from .commands import parse_command, parse_query, resolve_window_days
+from .config import Config
+from .db import (
+    add_clusters,
+    delete_buckets_by_theme,
+    delete_cluster,
+    delete_theme,
+    ensure_schema,
+    get_bucket_days,
+    get_clusters,
+    get_expanded_charset,
+    get_theme,
+    list_themes,
+    replace_clusters,
+    save_charsets,
+    upsert_theme,
+)
+
+scheduler = require("nonebot_plugin_apscheduler").scheduler
+
+SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+
+__plugin_meta__ = PluginMetadata(
+    name="word_pulse",
+    description="群聊主题词频统计 — 注册主题 → 日桶 AI 分类 → 热度总结",
+    usage=(
+        "词频 add 主题 种子词... —— 创建主题\n"
+        "词频 append 主题 种子词... —— 追加子类\n"
+        "词频 list —— 列出本群主题\n"
+        "词频 del 主题 —— 删除主题\n"
+        "词频 del 主题 子类 —— 删除子类\n"
+        "词频 refresh 主题 —— 刷新字符集\n"
+        "总结 N天/周/月 主题 —— 查询热度统计"
+    ),
+    config=Config,
+)
+
+config: Config = get_plugin_config(Config)
+driver = get_driver()
+SUPERUSERS: set[str] = set(driver.config.superusers)
+
+
+@driver.on_startup
+async def _init_word_pulse_schema() -> None:
+    """启动时初始化表结构。"""
+    ensure_schema()
+
+
+# ── Permission rule ──
+
+word_pulse_rule = create_group_rule(lambda: config, "word_pulse_plugin_enabled", "word_pulse_")
+
+# ── Matchers ──
+
+admin_matcher = on_regex(r"^词频\s+(add|append|list|del|refresh)\b.*", rule=word_pulse_rule, priority=5, block=True)
+query_matcher = on_regex(r"^总结\s+\d+\s*(天|d|周|w|月|m)\s+\S+", rule=word_pulse_rule, priority=5, block=True)
+
+# ── Cooldown & Cache ──
+
+cooldown_dict: dict[str, float] = {}
+
+
+@dataclass(slots=True)
+class CachedResult:
+    created_at: float
+    response_text: str
+
+
+result_cache: dict[str, CachedResult] = {}
+_cache_ttl = config.word_pulse_cache_ttl_minutes * 60
+
+
+def _cache_key(gid: int, theme: str, sig: str) -> str:
+    return hashlib.md5(f"{gid}:{theme}:{sig}".encode(), usedforsecurity=False).hexdigest()
+
+
+def _get_cached(key: str) -> str | None:
+    now = time.time()
+    for k in list(result_cache.keys()):
+        if now - result_cache[k].created_at >= _cache_ttl:
+            del result_cache[k]
+    cr = result_cache.get(key)
+    return cr.response_text if cr else None
+
+
+def _set_cached(key: str, text: str) -> None:
+    result_cache[key] = CachedResult(created_at=time.time(), response_text=text)
+
+
+def _cooldown_remaining(gid: int) -> int:
+    last = cooldown_dict.get(str(gid))
+    if last is None:
+        return 0
+    return max(0, int(last + config.word_pulse_cooldown_seconds - time.time()))
+
+
+def _mark_cooldown(gid: int) -> None:
+    cooldown_dict[str(gid)] = time.time()
+
+
+def _validate_config() -> str | None:
+    if not config.word_pulse_base_url.strip():
+        return "词频插件未配置 base_url"
+    if not config.word_pulse_api_key.strip():
+        return "词频插件未配置 api_key"
+    if not config.word_pulse_model.strip():
+        return "词频插件未配置 model"
+    return None
+
+
+def _is_admin(event: GroupMessageEvent) -> bool:
+    if str(event.user_id) in SUPERUSERS:
+        return True
+    return (event.sender.role if event.sender else "member") in ("owner", "admin")
+
+
+async def _ensure_group(event: MessageEvent) -> GroupMessageEvent:
+    if not isinstance(event, GroupMessageEvent):
+        await admin_matcher.finish("仅支持群聊使用")
+    return event
+
+
+# ── Admin handlers ──
+
+
+async def _run_expand_or_degrade(*, theme_id: int, seeds: list[str], theme_name: str, gid: str) -> str | None:
+    """调用 expand_charsets 并保存；失败时返回降级提示文案，成功返回 None。"""
+    try:
+        charsets = await expand_charsets(
+            base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
+            model=config.word_pulse_model, seeds=seeds, theme=theme_name,
+            temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
+        )
+        await save_charsets(theme_id, charsets)
+        await delete_buckets_by_theme(gid, theme_id)
+        return None
+    except WordPulseAIError as e:
+        logger.warning(f"[词频] 字符集扩展失败（已降级）: {e}")
+        return (
+            f"✓ 主题「{theme_name}」已创建（字符集扩展失败，已降级为纯精确匹配，"
+            f"可稍后重试「词频 refresh {theme_name}」）"
+        )
+
+
+@admin_matcher.handle()
+async def handle_admin(event: MessageEvent) -> None:
+    ge = await _ensure_group(event)
+    cmd = parse_command(event.raw_message.strip())
+    if cmd is None:
+        await admin_matcher.finish("命令格式错误")
+        return
+    if cmd.action != "list" and not _is_admin(ge):
+        await admin_matcher.finish("仅群管理或 Bot 管理员可使用此命令")
+        return
+    handlers = {
+        "add": _handle_add, "append": _handle_append, "list": _handle_list,
+        "del": _handle_del, "refresh": _handle_refresh,
+    }
+    try:
+        await handlers[cmd.action](ge, cmd)
+    except MatcherException:
+        # NoneBot 控制流异常（如 FinishedException）必须向上抛出，不能吞掉
+        raise
+    except Exception as e:
+        logger.error(f"[词频] {cmd.action} 失败: {e}", exc_info=True)
+        await admin_matcher.finish(f"操作失败：{e}")
+
+
+async def _handle_add(event: GroupMessageEvent, cmd) -> None:
+    gid = str(event.group_id)
+    tid = await upsert_theme(gid, cmd.theme)
+    await replace_clusters(tid, cmd.seeds)
+    degraded = await _run_expand_or_degrade(theme_id=tid, seeds=cmd.seeds, theme_name=cmd.theme, gid=gid)
+    if degraded is not None:
+        await admin_matcher.finish(degraded)
+        return
+    await admin_matcher.finish(f"✓ 主题「{cmd.theme}」已创建（覆盖式）\n  子类：{'、'.join(cmd.seeds)}")
+
+
+async def _handle_append(event: GroupMessageEvent, cmd) -> None:
+    gid = str(event.group_id)
+    theme = await get_theme(gid, cmd.theme)
+    if theme is None:
+        await admin_matcher.finish(f"本群尚未创建主题「{cmd.theme}」")
+        return
+    new_ids = await add_clusters(theme["id"], cmd.seeds)
+    if not new_ids:
+        await admin_matcher.finish(f"子类「{'、'.join(cmd.seeds)}」已存在")
+        return
+    new_seeds = [cmd.seeds[i] for i in range(len(cmd.seeds)) if i < len(new_ids)]
+    try:
+        charsets = await expand_charsets(
+            base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
+            model=config.word_pulse_model, seeds=new_seeds, theme=cmd.theme,
+            temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
+        )
+        await save_charsets(theme["id"], charsets)
+    except WordPulseAIError as e:
+        logger.warning(f"[词频] append 字符集扩展失败: {e}")
+    await delete_buckets_by_theme(gid, theme["id"])
+    await admin_matcher.finish(f"✓ 已追加子类到「{cmd.theme}」：{'、'.join(cmd.seeds)}")
+
+
+async def _handle_list(event: GroupMessageEvent, _cmd=None) -> None:
+    themes = await list_themes(str(event.group_id))
+    if not themes:
+        await admin_matcher.finish("本群暂无主题")
+        return
+    lines = ["📊 本群主题列表："]
+    for t in themes:
+        cls = await get_clusters(t["id"])
+        seeds = "、".join(c["name"] for c in cls) or "（无子类）"
+        lines.append(f"  · {t['name']} — {seeds}")
+    await admin_matcher.finish("\n".join(lines))
+
+
+async def _handle_del(event: GroupMessageEvent, cmd) -> None:
+    theme = await get_theme(str(event.group_id), cmd.theme)
+    if theme is None:
+        await admin_matcher.finish(f"本群尚未创建主题「{cmd.theme}」")
+        return
+    if cmd.seeds:
+        cls = await get_clusters(theme["id"])
+        target = [c for c in cls if c["name"] == cmd.seeds[0]]
+        if not target:
+            await admin_matcher.finish(f"主题「{cmd.theme}」中没有子类「{cmd.seeds[0]}」")
+            return
+        await delete_cluster(target[0]["id"])
+        await delete_buckets_by_theme(str(event.group_id), theme["id"])
+        await admin_matcher.finish(f"✓ 已从「{cmd.theme}」删除子类「{cmd.seeds[0]}」")
+        return
+    await delete_theme(theme["id"])
+    await admin_matcher.finish(f"✓ 已删除主题「{cmd.theme}」")
+
+
+async def _handle_refresh(event: GroupMessageEvent, cmd) -> None:
+    theme = await get_theme(str(event.group_id), cmd.theme)
+    if theme is None:
+        await admin_matcher.finish(f"本群尚未创建主题「{cmd.theme}」")
+        return
+    cls = await get_clusters(theme["id"])
+    if not cls:
+        await admin_matcher.finish(f"主题「{cmd.theme}」没有任何子类")
+        return
+    seeds = [c["name"] for c in cls]
+    degraded = await _run_expand_or_degrade(theme_id=theme["id"], seeds=seeds, theme_name=cmd.theme, gid=str(event.group_id))
+    if degraded is not None:
+        await admin_matcher.finish("字符集刷新失败，请稍后重试或检查 AI 配置")
+        return
+    await admin_matcher.finish(f"✓ 主题「{cmd.theme}」字符集已刷新（{len(seeds)} 个子类）\n  子类：{'、'.join(seeds)}")
+
+
+# ── Query handler ──
+
+
+async def _resolve_query_target(ge: GroupMessageEvent, query) -> tuple[dict, list[dict], str] | str:
+    """解析主题/子类/字符池，返回 (theme, clusters, cache_key) 或错误文案。"""
+    gid = str(ge.group_id)
+    theme = await get_theme(gid, query.theme)
+    if theme is None:
+        return f"本群尚未创建主题「{query.theme}」"
+    clusters = await get_clusters(theme["id"])
+    if not clusters:
+        return f"主题「{query.theme}」没有任何子类"
+    bucket_days = await get_bucket_days(gid, theme["id"])
+    sig = hashlib.md5("".join(sorted(bucket_days)).encode(), usedforsecurity=False).hexdigest()[:8]
+    ck = _cache_key(ge.group_id, query.theme, f"{query.window_value}{query.window_unit}:{sig}")
+    return theme, clusters, ck
+
+
+async def _run_summary(*, query, theme: dict, clusters: list[dict], buckets: list[dict], window_desc: str) -> str:
+    prompt = build_summary_prompt(
+        theme_name=query.theme, clusters=clusters, buckets=buckets,
+        window_meta=window_desc, max_examples=config.word_pulse_max_examples_in_summary,
+    )
+    try:
+        summary = await summarize(
+            base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
+            model=config.word_pulse_model, prompt=prompt,
+            temperature=config.word_pulse_summary_temperature, timeout=config.word_pulse_timeout_seconds,
+        )
+    except WordPulseAITimeoutError:
+        return "AI 总结超时，请稍后重试"
+    except WordPulseAIAuthError:
+        return "AI 鉴权失败，请检查 API Key"
+    except WordPulseAIResponseError:
+        return "AI 返回格式异常"
+    except WordPulseAIServiceError as e:
+        logger.error(f"[词频] AI 服务异常: {e}", exc_info=True)
+        return "AI 服务暂时不可用"
+    except Exception as e:
+        logger.error(f"[词频] 总结失败: {e}", exc_info=True)
+        return "AI 总结失败"
+    return _render_summary(query.theme, window_desc, buckets, summary)
+
+
+@query_matcher.handle()
+async def handle_query(event: MessageEvent) -> None:
+    ge = await _ensure_group(event)
+    query = parse_query(event.raw_message.strip())
+    if query is None:
+        await query_matcher.finish("查询格式错误")
+        return
+    cfg_err = _validate_config()
+    if cfg_err:
+        await query_matcher.finish(cfg_err)
+        return
+    total_days = resolve_window_days(query.window_value, query.window_unit, config.word_pulse_max_window_days)
+    if total_days is None:
+        await query_matcher.finish(f"时间范围超过上限 {config.word_pulse_max_window_days} 天")
+        return
+    resolved = await _resolve_query_target(ge, query)
+    if isinstance(resolved, str):
+        await query_matcher.finish(resolved)
+        return
+    theme, clusters, ck = resolved
+    cached = _get_cached(ck)
+    if cached:
+        await query_matcher.finish(cached)
+        return
+    remaining = _cooldown_remaining(ge.group_id)
+    if remaining > 0:
+        await query_matcher.finish(f"冷却中，请等待 {remaining} 秒")
+        return
+    _mark_cooldown(ge.group_id)
+    buckets = await _compute_buckets(ge, query, theme, clusters, total_days)
+    window_desc = _build_window_desc(query, total_days)
+    resp = await _run_summary(query=query, theme=theme, clusters=clusters, buckets=buckets, window_desc=window_desc)
+    _set_cached(ck, resp)
+    await query_matcher.finish(resp)
+
+
+async def _compute_buckets(ge: GroupMessageEvent, query, theme: dict, clusters: list[dict], total_days: int) -> list[dict]:
+    seed_chars = set("".join(c["name"] for c in clusters))
+    expanded = await get_expanded_charset(theme["id"])
+    char_pool = seed_chars | expanded
+    cluster_terms = {c["name"]: {c["name"]} for c in clusters}
+    return await compute_or_load_buckets(
+        group_id=str(ge.group_id), theme_id=theme["id"], theme_name=query.theme, clusters=clusters,
+        char_pool=char_pool, cluster_terms=cluster_terms, day_range=total_days,
+        base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key, model=config.word_pulse_model,
+        max_messages_per_bucket=config.word_pulse_max_messages_per_bucket,
+        max_sample_per_cluster=config.word_pulse_max_sample_per_cluster,
+        temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
+        today_bucket_fresh_seconds=config.word_pulse_today_bucket_fresh_seconds,
+    )
+
+
+def _build_window_desc(query, total_days: int) -> str:
+    now_dt = datetime.now(SHANGHAI_TZ)
+    start = (now_dt - timedelta(days=total_days - 1)).strftime("%Y-%m-%d")
+    end = now_dt.strftime("%Y-%m-%d")
+    unit_disp = {"d": "天", "w": "周", "m": "月"}.get(query.window_unit, query.window_unit)
+    return f"{query.window_value}{unit_disp} ({start} ~ {end})"
+
+
+def _render_summary(theme: str, window: str, buckets: list[dict], summary) -> str:
+    total: dict[str, int] = {}
+    for b in buckets:
+        for k, v in b.get("counts", {}).items():
+            total[k] = total.get(k, 0) + v
+    grand = sum(total.values())
+    lines = [f"📊 {theme}主题 · {window}", "━" * 30, "排名  子类     计数   占比"]
+    for idx, item in enumerate(summary.ranking, 1):
+        lines.append(f"{idx}.   {item.cluster:<6} {item.count:<6} {item.percent}%")
+    if "_other" in total:
+        pct = "0" if grand == 0 else f"{round(total['_other'] / grand * 100)}%"
+        lines.append(f"-     其他      {total['_other']:<6} {pct}")
+    lines.append(f"-     跳过      {total.get('_skipped', 0)}")
+    lines.append("━" * 30)
+    lines.append(f"📈 趋势：{summary.trend}")
+    if summary.examples:
+        lines.append("💬 典型原文：")
+        for ex in summary.examples[:5]:
+            lines.append(f"  · \"{ex.text}\" — {ex.author} {ex.day}")
+    if summary.unclassified_high_freq:
+        terms = "· ".join(f"{t.term}（{t.count}）" for t in summary.unclassified_high_freq[:8])
+        lines.append(f"🔍 新发现的可能相关词（未归类）：\n  · {terms}")
+    return "\n".join(lines)
+
+
+# ── APScheduler cleanup ──
+
+
+@scheduler.scheduled_job("cron", hour=3, minute=0, id="word_pulse_daily_cleanup", misfire_grace_time=300)
+async def daily_cleanup() -> None:
+    from .db import delete_buckets_older_than  # noqa: PLC0415
+    cutoff = (datetime.now(SHANGHAI_TZ) - timedelta(days=config.word_pulse_bucket_retention_days)).strftime("%Y-%m-%d")
+    deleted = await delete_buckets_older_than(cutoff)
+    if deleted:
+        logger.info(f"[词频] 清理了 {deleted} 条过期桶（< {cutoff}）")
+    now = time.time()
+    expired = [k for k in list(result_cache.keys()) if now - result_cache[k].created_at >= _cache_ttl]
+    for k in expired:
+        del result_cache[k]
+    if expired:
+        logger.info(f"[词频] 清理了 {len(expired)} 条缓存")

--- a/src/plugins/word_pulse/ai.py
+++ b/src/plugins/word_pulse/ai.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+from nonebot import logger
+from pydantic import BaseModel, Field, ValidationError
+
+
+class WordPulseAIError(Exception):
+    """AI 分析失败基类。"""
+
+
+class WordPulseAITimeoutError(WordPulseAIError):
+    """AI 请求超时。"""
+
+
+class WordPulseAIAuthError(WordPulseAIError):
+    """AI 鉴权失败。"""
+
+
+class WordPulseAIServiceError(WordPulseAIError):
+    """AI 服务异常。"""
+
+
+class WordPulseAIResponseError(WordPulseAIError):
+    """AI 返回格式异常。"""
+
+
+class CharsetItem(BaseModel):
+    cluster: str
+    chars: list[str] = Field(min_length=5, max_length=30)
+
+
+class CharsetExpansionResponse(BaseModel):
+    charsets: list[CharsetItem]
+
+
+class BatchClassifyItem(BaseModel):
+    id: int
+    cluster: str | None
+
+
+class BatchClassificationResponse(BaseModel):
+    results: list[BatchClassifyItem]
+
+
+class RankItem(BaseModel):
+    cluster: str
+    count: int
+    percent: float
+
+
+class ExampleItem(BaseModel):
+    cluster: str
+    text: str
+    author: str
+    day: str
+
+
+class UnclassifiedTerm(BaseModel):
+    term: str
+    count: int
+
+
+class SummaryResult(BaseModel):
+    ranking: list[RankItem]
+    trend: str
+    examples: list[ExampleItem] = Field(max_length=5)
+    unclassified_high_freq: list[UnclassifiedTerm] = Field(max_length=8)
+
+
+# ── Shared HTTP helper ──
+
+
+def _build_url(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/chat/completions"
+
+
+def _extract_content(payload: dict) -> str:
+    """从 OpenAI 兼容响应里取出 message.content 字符串。"""
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise WordPulseAIResponseError("响应中缺少 choices")
+    msg = choices[0].get("message")
+    if not isinstance(msg, dict):
+        raise WordPulseAIResponseError("响应中缺少 message")
+    content = msg.get("content")
+    if not isinstance(content, str):
+        raise WordPulseAIResponseError("响应中缺少 content")
+    return content
+
+
+async def _request_llm(
+    *, base_url: str, api_key: str, model: str,
+    messages: list[dict], response_schema: dict,
+    temperature: float, timeout_seconds: float,
+) -> dict:
+    """发送 OpenAI 兼容请求并返回解析后的 JSON dict。
+
+    优先尝试 ``response_format: json_schema strict``（OpenAI 官方支持）。
+    若上游 API 返回 400（表明不支持 strict schema），自动降级为
+    ``response_format: json_object`` 重试，由 pydantic 校验兜底 schema。
+    """
+    url = _build_url(base_url)
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    base_body: dict = {"model": model, "temperature": temperature, "messages": messages}
+
+    # 优先 strict json_schema
+    strict_body = dict(base_body)
+    strict_body["response_format"] = {
+        "type": "json_schema",
+        "json_schema": {"name": "response", "schema": response_schema, "strict": True},
+    }
+    try:
+        resp = await _post_with_fallback(
+            url=url, headers=headers, strict_body=strict_body,
+            fallback_body={**base_body, "response_format": {"type": "json_object"}},
+            timeout_seconds=timeout_seconds, model=model,
+        )
+    except _LLMRequestError:
+        raise
+
+    try:
+        payload = resp.json()
+    except json.JSONDecodeError as e:
+        raise WordPulseAIResponseError("AI 接口返回不是合法 JSON") from e
+    if not isinstance(payload, dict):
+        raise WordPulseAIResponseError("AI 接口响应格式不正确")
+    content = _extract_content(payload)
+    logger.debug(f"[词频统计] AI 原始输出: {content}")
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        raise WordPulseAIResponseError("模型输出不是合法 JSON") from e
+
+
+class _LLMRequestError(Exception):
+    """内部信号：已转换为 WordPulseAI* 异常，直接 raise。"""
+
+
+async def _post_with_fallback(
+    *, url: str, headers: dict, strict_body: dict, fallback_body: dict,
+    timeout_seconds: float, model: str,
+) -> httpx.Response:
+    """先发 strict 请求；400 时降级 fallback；其他错误按异常分层抛出。"""
+    try:
+        async with httpx.AsyncClient(timeout=timeout_seconds, trust_env=False) as client:
+            resp = await client.post(url, headers=headers, json=strict_body)
+            resp.raise_for_status()
+            return resp
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code != 400:
+            raise _to_ai_error(e) from e
+        # 400 通常意味着上游不支持 strict json_schema，降级为 json_object
+        logger.warning(
+            f"[词频统计] json_schema strict 返回 400，降级为 json_object（model={model}）"
+        )
+        try:
+            async with httpx.AsyncClient(timeout=timeout_seconds, trust_env=False) as client:
+                resp = await client.post(url, headers=headers, json=fallback_body)
+                resp.raise_for_status()
+                return resp
+        except httpx.HTTPStatusError as e2:
+            raise _to_ai_error(e2) from e2
+        except httpx.TimeoutException as e2:
+            raise WordPulseAITimeoutError("AI 请求超时") from e2
+        except httpx.RequestError as e2:
+            raise WordPulseAIServiceError("AI 请求失败") from e2
+    except httpx.TimeoutException as e:
+        raise WordPulseAITimeoutError("AI 请求超时") from e
+    except httpx.RequestError as e:
+        raise WordPulseAIServiceError("AI 请求失败") from e
+    raise _LLMRequestError("unreachable")
+
+
+def _to_ai_error(e: httpx.HTTPStatusError) -> WordPulseAIError:
+    """把 HTTPStatusError 按状态码映射到对应的 WordPulseAI* 异常。"""
+    if e.response.status_code in {401, 403}:
+        return WordPulseAIAuthError("AI 鉴权失败")
+    return WordPulseAIServiceError(f"AI 服务返回 HTTP {e.response.status_code}")
+
+
+# ── Call 1: Charset expansion ──
+
+
+_CHARSET_SYSTEM = (
+    "你是中文群聊话题分类助手。给定主题与子类（cluster）种子词，"
+    "为每个 cluster 列出该话题语境下语义相关的中文字符（用于粗过滤）。"
+    "只返回字符（单字），不要返回词。宁可多列不可漏列。\n"
+    "必须返回严格 JSON，schema 形如：\n"
+    '{"charsets": [{"cluster": "种子词", "chars": ["字1", "字2", ...]}]}\n'
+    "每个 cluster 的 chars 数组必须含 5-30 个字符。"
+)
+_CHARSET_SCHEMA = {
+    "type": "object", "required": ["charsets"], "properties": {
+        "charsets": {
+            "type": "array", "items": {
+                "type": "object", "required": ["cluster", "chars"], "properties": {
+                    "cluster": {"type": "string"},
+                    "chars": {"type": "array", "items": {"type": "string"}, "minItems": 5, "maxItems": 30},
+                },
+            },
+        },
+    },
+}
+
+
+async def expand_charsets(
+    *, base_url: str, api_key: str, model: str,
+    seeds: list[str], theme: str, temperature: float = 0.0, timeout: float = 60.0,
+) -> dict[str, list[str]]:
+    cluster_lines = "\n".join(f"- {s}" for s in seeds)
+    parsed = await _request_llm(
+        base_url=base_url, api_key=api_key, model=model,
+        messages=[{"role": "system", "content": _CHARSET_SYSTEM},
+                  {"role": "user", "content": f"主题：{theme}\n子类种子词：\n{cluster_lines}\n\n请为每个子类列出 5-30 个语义相关的中文字符。"}],
+        response_schema=_CHARSET_SCHEMA, temperature=temperature, timeout_seconds=timeout,
+    )
+    try:
+        validated = CharsetExpansionResponse.model_validate(parsed)
+    except ValidationError as e:
+        raise WordPulseAIResponseError(f"字符集扩展返回格式异常: {e}") from e
+    return {item.cluster: item.chars for item in validated.charsets}
+
+
+# ── Call 2: Grey-area batch classification ──
+
+
+_BATCH_CLASSIFY_SCHEMA = {
+    "type": "object", "required": ["results"], "properties": {
+        "results": {
+            "type": "array", "items": {
+                "type": "object", "required": ["id", "cluster"], "properties": {
+                    "id": {"type": "integer"}, "cluster": {"type": ["string", "null"]},
+                },
+            },
+        },
+    },
+}
+_BATCH_SYSTEM = (
+    "你是中文群聊话题分类助手。给定主题与子类簇定义，"
+    "把每条消息归到一个最匹配的子类或 null（表示不属于该主题）。\n"
+    "必须返回严格 JSON，schema 形如：\n"
+    '{"results": [{"id": <消息id>, "cluster": "子类名" 或 null}]}\n'
+    "results 数组必须为每条输入消息返回一个条目，id 与输入消息的 [id] 对应。"
+)
+
+
+async def classify_batch(
+    *, base_url: str, api_key: str, model: str,
+    messages: list[tuple[int, str]], clusters: list[dict], theme_name: str,
+    temperature: float = 0.0, timeout: float = 60.0, max_batch_size: int = 1000,
+) -> list[tuple[int, str | None]]:
+    if not messages:
+        return []
+    cluster_lines = "\n".join(f"- {c['name']}" for c in clusters)
+    all_results: list[tuple[int, str | None]] = []
+    for start in range(0, len(messages), max_batch_size):
+        chunk = messages[start:start + max_batch_size]
+        msg_lines = "\n".join(f"[{mid}] {txt}" for mid, txt in chunk)
+        parsed = await _request_llm(
+            base_url=base_url, api_key=api_key, model=model,
+            messages=[{"role": "system", "content": _BATCH_SYSTEM},
+                      {"role": "user", "content": f"主题：{theme_name}\n子类：\n{cluster_lines}\n\n消息：\n{msg_lines}"}],
+            response_schema=_BATCH_CLASSIFY_SCHEMA, temperature=temperature, timeout_seconds=timeout,
+        )
+        try:
+            validated = BatchClassificationResponse.model_validate(parsed)
+        except ValidationError as e:
+            raise WordPulseAIResponseError(f"批量分类返回格式异常: {e}") from e
+        all_results.extend((item.id, item.cluster) for item in validated.results)
+    return all_results
+
+
+# ── Call 3: Final summary ──
+
+
+_SUMMARY_SCHEMA = {
+    "type": "object", "required": ["ranking", "trend", "examples", "unclassified_high_freq"], "properties": {
+        "ranking": {"type": "array", "items": {"type": "object", "required": ["cluster", "count", "percent"], "properties": {"cluster": {"type": "string"}, "count": {"type": "integer"}, "percent": {"type": "number"}}}},
+        "trend": {"type": "string"},
+        "examples": {"type": "array", "items": {"type": "object", "required": ["cluster", "text", "author", "day"], "properties": {"cluster": {"type": "string"}, "text": {"type": "string"}, "author": {"type": "string"}, "day": {"type": "string"}}}, "maxItems": 5},
+        "unclassified_high_freq": {"type": "array", "items": {"type": "object", "required": ["term", "count"], "properties": {"term": {"type": "string"}, "count": {"type": "integer"}}}, "maxItems": 8},
+    },
+}
+_SUMMARY_SYSTEM = (
+    "你是中文群聊话题热度分析助手。根据提供的日桶统计数据，"
+    "给出主题讨论的趋势总结和典型原文。趋势总结 ≤ 80 字。\n"
+    "必须返回严格 JSON，schema 形如：\n"
+    '{"ranking": [{"cluster": "x", "count": N, "percent": M}], '
+    '"trend": "≤80字趋势总结", '
+    '"examples": [{"cluster": "x", "text": "原文", "author": "发言人", "day": "YYYY-MM-DD"}], '
+    '"unclassified_high_freq": [{"term": "词", "count": N}]}\n'
+    "examples 最多 5 条；unclassified_high_freq 最多 8 条。"
+)
+
+
+async def summarize(
+    *, base_url: str, api_key: str, model: str,
+    prompt: str, temperature: float = 0.3, timeout: float = 60.0,
+) -> SummaryResult:
+    parsed = await _request_llm(
+        base_url=base_url, api_key=api_key, model=model,
+        messages=[{"role": "system", "content": _SUMMARY_SYSTEM}, {"role": "user", "content": prompt}],
+        response_schema=_SUMMARY_SCHEMA, temperature=temperature, timeout_seconds=timeout,
+    )
+    try:
+        return SummaryResult.model_validate(parsed)
+    except ValidationError as e:
+        raise WordPulseAIResponseError(f"AI 总结返回格式异常: {e}") from e

--- a/src/plugins/word_pulse/analysis.py
+++ b/src/plugins/word_pulse/analysis.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, time, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+from src.plugins.message_archive.db import ArchivedMessage, fetch_group_messages_by_time_range
+from src.plugins.word_pulse.ai import classify_batch
+from src.plugins.word_pulse.db import delete_buckets_by_theme, get_bucket, save_bucket
+from src.storage import get_db
+
+SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+db = get_db()
+
+
+def classify_message(
+    msg_text: str, char_pool: set[str], cluster_terms: dict[str, set[str]],
+) -> list[str] | None | Literal["GREY"]:
+    if not msg_text:
+        return None
+    msg_chars = set(msg_text)
+    if not (msg_chars & char_pool):
+        return None
+    hits = [name for name, terms in cluster_terms.items() if any(t in msg_text for t in terms)]
+    if hits:
+        return hits
+    return "GREY"
+
+
+def uniform_sample(messages: list[ArchivedMessage], max_count: int) -> list[ArchivedMessage]:
+    if max_count <= 0:
+        return []
+    if len(messages) <= max_count:
+        return messages
+    if max_count == 1:
+        # 单条时取中间那条，避免下方循环 ZeroDivisionError
+        return [messages[len(messages) // 2]]
+    result: list[ArchivedMessage] = []
+    seen: set[int] = set()
+    last = len(messages) - 1
+    for i in range(max_count):
+        idx = round(i * last / (max_count - 1))
+        m = messages[idx]
+        if m.id not in seen:
+            seen.add(m.id)
+            result.append(m)
+    return sorted(result, key=lambda x: x.event_time)
+
+
+def _pick_evenly(items: list, count: int) -> list:
+    """从列表中均匀选取 count 个元素。"""
+    if count <= 0 or not items:
+        return []
+    if count >= len(items):
+        return items
+    result: list = []
+    last = len(items) - 1
+    for i in range(count):
+        idx = round(i * last / (count - 1))
+        result.append(items[idx])
+    return result
+
+
+def merge_results(
+    direct: list[tuple[int, list[str]]],
+    grey_classified: list[tuple[int, str | None]],
+    all_messages: dict[int, ArchivedMessage],
+    day_label: str,
+    skipped_count: int, max_sample: int = 3,
+) -> tuple[dict[str, int], list[dict]]:
+    """合并弱预筛直接归类 + LLM 灰区归类结果，按 cluster 抽样原文。
+
+    samples schema: [{"cluster": str, "text": str, "author": str, "day": str, "event_time": int}]
+    """
+    counts: dict[str, int] = {"_other": 0, "_skipped": skipped_count}
+    cluster_samples: dict[str, list[tuple[int, int, str, str]]] = {}  # cluster -> [(event_time, msg_id, text, author)]
+
+    def _record(cluster_name: str, msg_id: int) -> None:
+        counts[cluster_name] = counts.get(cluster_name, 0) + 1
+        msg = all_messages.get(msg_id)
+        if msg is None:
+            return
+        cs = cluster_samples.setdefault(cluster_name, [])
+        # 收集 2x 候选以便后续按 event_time 均匀抽样
+        if len(cs) < max_sample * 2:
+            cs.append((msg.event_time, msg.id, msg.plain_text, msg.sender_name))
+
+    for msg_id, clusters in direct:
+        for cl in clusters:
+            _record(cl, msg_id)
+
+    for msg_id, cluster_name in grey_classified:
+        if cluster_name is not None:
+            _record(cluster_name, msg_id)
+        else:
+            counts["_other"] += 1
+
+    # Build samples: per cluster pick max_sample items evenly distributed by event_time
+    samples: list[dict] = []
+    for cl_name, items in cluster_samples.items():
+        items.sort(key=lambda x: x[0])  # sort by event_time
+        selected = _pick_evenly(items, min(max_sample, len(items)))
+        for et, _mid, text, author in selected:
+            samples.append({
+                "cluster": cl_name,
+                "text": text,
+                "author": author,
+                "day": day_label,
+                "event_time": et,
+            })
+
+    return counts, samples
+
+
+def build_summary_prompt(
+    theme_name: str, clusters: list[dict], buckets: list[dict], window_meta: str, max_examples: int = 5,
+) -> str:
+    cluster_defs = "\n".join(f"- {c['name']}" for c in clusters)
+    day_lines: list[str] = []
+    samples: list[dict] = []
+    for b in buckets:
+        day_lines.append(f"  [{b['day']}] 总{b['total_messages']}条 | " + ", ".join(f"{k}:{v}" for k, v in sorted(b.get("counts", {}).items()) if k != "_skipped"))
+        samples.extend(b.get("samples", []))
+    parts = [f"主题：{theme_name}", f"时间范围：{window_meta}", f"子类：\n{cluster_defs}", "", "日桶统计：", *day_lines]
+    if samples:
+        parts.append("")
+        parts.append("典型原文：")
+        for s in samples[:max_examples]:
+            parts.append(f"  [{s['day']}] {s['author']}: {s['text']} (→ {s['cluster']})")
+    return "\n".join(parts)
+
+
+def _bucket_from_cache(cached: dict) -> dict:
+    return {
+        "day": cached["day"],
+        "total_messages": cached["total_messages"],
+        "counts": json.loads(cached["counts_json"]),
+        "samples": json.loads(cached["samples_json"]),
+        "sampled": bool(cached["sampled"]),
+    }
+
+
+async def _compute_day_bucket(
+    *, group_id: str, theme_id: int, theme_name: str, day: str, day_dt: datetime,
+    clusters: list[dict], char_pool: set[str], cluster_terms: dict[str, set[str]],
+    max_messages_per_bucket: int, max_sample_per_cluster: int,
+    base_url: str, api_key: str, model: str, temperature: float, timeout: float,
+) -> dict:
+    day_start = int(datetime.combine(day_dt.date(), time.min, SHANGHAI_TZ).timestamp())
+    messages = await fetch_group_messages_by_time_range(
+        group_id=group_id, start_time=day_start, end_time=day_start + 86400,
+    )
+    if not messages:
+        empty = json.dumps({"_other": 0, "_skipped": 0}, ensure_ascii=False)
+        await save_bucket(group_id, theme_id, day, empty, "[]", 0, False)
+        return {"day": day, "total_messages": 0, "counts": {"_other": 0, "_skipped": 0}, "samples": [], "sampled": False}
+
+    sampled_flag = False
+    if len(messages) > max_messages_per_bucket:
+        messages = uniform_sample(messages, max_messages_per_bucket)
+        sampled_flag = True
+
+    direct: list[tuple[int, list[str]]] = []
+    grey_msgs: list[tuple[int, str]] = []
+    skipped = 0
+    all_msg_map: dict[int, ArchivedMessage] = {}
+    for msg in messages:
+        all_msg_map[msg.id] = msg
+        r = classify_message(msg.plain_text, char_pool, cluster_terms)
+        if r is None:
+            skipped += 1
+        elif r == "GREY":
+            grey_msgs.append((msg.id, msg.plain_text))
+        else:
+            direct.append((msg.id, r))
+
+    grey_classified: list[tuple[int, str | None]] = []
+    if grey_msgs:
+        grey_classified = await classify_batch(
+            base_url=base_url, api_key=api_key, model=model, messages=grey_msgs,
+            clusters=clusters, theme_name=theme_name, temperature=temperature, timeout=timeout,
+        )
+
+    counts, samples = merge_results(direct, grey_classified, all_msg_map, day, skipped, max_sample_per_cluster)
+    await save_bucket(
+        group_id, theme_id, day,
+        json.dumps(counts, ensure_ascii=False), json.dumps(samples, ensure_ascii=False),
+        len(messages), sampled_flag,
+    )
+    return {"day": day, "total_messages": len(messages), "counts": counts, "samples": samples, "sampled": sampled_flag}
+
+
+async def compute_or_load_buckets(
+    *, group_id: str, theme_id: int, theme_name: str,
+    clusters: list[dict], char_pool: set[str], cluster_terms: dict[str, set[str]],
+    day_range: int, base_url: str, api_key: str, model: str,
+    max_messages_per_bucket: int, max_sample_per_cluster: int,
+    temperature: float, timeout: float,
+    today_bucket_fresh_seconds: int = 300,
+) -> list[dict]:
+    now_dt = datetime.now(SHANGHAI_TZ)
+    today = now_dt.strftime("%Y-%m-%d")
+    now_ts = int(now_dt.timestamp())
+    results: list[dict] = []
+    for offset in range(day_range):
+        day_dt = now_dt - timedelta(days=offset)
+        day = day_dt.strftime("%Y-%m-%d")
+        cached = await get_bucket(group_id, theme_id, day)
+        if cached:
+            computed_at = cached["computed_at"]
+            # History days: indefinitely cached. Today: fresh within window.
+            if day < today:
+                results.append(_bucket_from_cache(cached))
+                continue
+            if day == today and (now_ts - computed_at) < today_bucket_fresh_seconds:
+                results.append(_bucket_from_cache(cached))
+                continue
+        bucket = await _compute_day_bucket(
+            group_id=group_id, theme_id=theme_id, theme_name=theme_name, day=day, day_dt=day_dt,
+            clusters=clusters, char_pool=char_pool, cluster_terms=cluster_terms,
+            max_messages_per_bucket=max_messages_per_bucket, max_sample_per_cluster=max_sample_per_cluster,
+            base_url=base_url, api_key=api_key, model=model, temperature=temperature, timeout=timeout,
+        )
+        results.append(bucket)
+    results.reverse()
+    return results
+
+
+# Re-export delete_buckets_by_theme for callers that invalidate on cluster change.
+__all__ = [
+    "SHANGHAI_TZ",
+    "build_summary_prompt",
+    "classify_message",
+    "compute_or_load_buckets",
+    "delete_buckets_by_theme",
+    "merge_results",
+    "uniform_sample",
+]

--- a/src/plugins/word_pulse/commands.py
+++ b/src/plugins/word_pulse/commands.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ParsedCommand:
+    action: str  # add / append / list / del / refresh
+    theme: str | None = None
+    seeds: list[str] | None = None
+
+
+@dataclass(slots=True)
+class ParsedQuery:
+    window_value: int
+    window_unit: str
+    theme: str
+
+
+_PREFIX = "词频"
+_QUERY_P = "总结"
+
+_CMD_ADD = re.compile(rf"^{_PREFIX}\s+add\s+(\S+)\s+(.+)$")
+_CMD_APPEND = re.compile(rf"^{_PREFIX}\s+append\s+(\S+)\s+(.+)$")
+_CMD_LIST = re.compile(rf"^{_PREFIX}\s+list$")
+_CMD_DEL_CLUSTER = re.compile(rf"^{_PREFIX}\s+del\s+(\S+)\s+(\S+)$")
+_CMD_DEL_THEME = re.compile(rf"^{_PREFIX}\s+del\s+(\S+)$")
+_CMD_REFRESH = re.compile(rf"^{_PREFIX}\s+refresh\s+(\S+)$")
+_QUERY_RE = re.compile(rf"^{_QUERY_P}\s+(\d+)\s*(天|d|周|w|月|m)\s+(\S+)$")
+
+
+def parse_command(text: str) -> ParsedCommand | None:
+    m = _CMD_DEL_CLUSTER.match(text)
+    if m:
+        return ParsedCommand(action="del", theme=m.group(1), seeds=[m.group(2)])
+    m = _CMD_DEL_THEME.match(text)
+    if m:
+        return ParsedCommand(action="del", theme=m.group(1))
+    m = _CMD_ADD.match(text)
+    if m:
+        seeds = [s for s in re.split(r"\s+", m.group(2).strip()) if s]
+        return ParsedCommand(action="add", theme=m.group(1), seeds=seeds)
+    m = _CMD_APPEND.match(text)
+    if m:
+        seeds = [s for s in re.split(r"\s+", m.group(2).strip()) if s]
+        return ParsedCommand(action="append", theme=m.group(1), seeds=seeds)
+    m = _CMD_LIST.match(text)
+    if m:
+        return ParsedCommand(action="list")
+    m = _CMD_REFRESH.match(text)
+    if m:
+        return ParsedCommand(action="refresh", theme=m.group(1))
+    return None
+
+
+def parse_query(text: str) -> ParsedQuery | None:
+    m = _QUERY_RE.match(text)
+    if not m:
+        return None
+    return ParsedQuery(window_value=int(m.group(1)), window_unit=m.group(2), theme=m.group(3))
+
+
+def resolve_window_days(value: int, unit: str, max_days: int) -> int | None:
+    multiplier = {"天": 1, "d": 1, "周": 7, "w": 7, "月": 31, "m": 31}.get(unit)
+    if multiplier is None:
+        return None
+    total = value * multiplier
+    return None if total > max_days else total

--- a/src/plugins/word_pulse/config.py
+++ b/src/plugins/word_pulse/config.py
@@ -1,0 +1,22 @@
+# src/plugins/word_pulse/config.py
+from pydantic import BaseModel, Field
+
+from src.plugins.group_permission import GroupPermissionMixin
+
+
+class Config(GroupPermissionMixin, BaseModel):
+    word_pulse_plugin_enabled: bool = Field(default=False, description="是否启用词频统计插件")
+    word_pulse_base_url: str = Field(default="", description="OpenAI 兼容接口的 Base URL")
+    word_pulse_api_key: str = Field(default="", description="OpenAI 兼容接口的 API Key")
+    word_pulse_model: str = Field(default="", description="OpenAI 兼容接口的模型名称")
+    word_pulse_temperature: float = Field(default=0.0, ge=0, le=2, description="分类温度")
+    word_pulse_summary_temperature: float = Field(default=0.3, ge=0, le=2, description="汇总温度")
+    word_pulse_timeout_seconds: float = Field(default=60.0, gt=0, le=300, description="AI请求超时")
+    word_pulse_cooldown_seconds: int = Field(default=30, ge=0, le=3600, description="查询冷却秒数")
+    word_pulse_cache_ttl_minutes: int = Field(default=5, ge=1, le=1440, description="结果缓存分钟")
+    word_pulse_bucket_retention_days: int = Field(default=30, ge=1, le=365, description="桶保留天数")
+    word_pulse_max_messages_per_bucket: int = Field(default=1000, ge=100, le=10000, description="单桶消息上限")
+    word_pulse_max_sample_per_cluster: int = Field(default=3, ge=1, le=10, description="每cluster抽样条数")
+    word_pulse_max_examples_in_summary: int = Field(default=5, ge=1, le=20, description="总结中原文条数")
+    word_pulse_max_window_days: int = Field(default=31, ge=1, le=365, description="查询窗口上限天")
+    word_pulse_today_bucket_fresh_seconds: int = Field(default=300, ge=60, le=3600, description="今日桶 freshness 窗口秒数")

--- a/src/plugins/word_pulse/db.py
+++ b/src/plugins/word_pulse/db.py
@@ -1,0 +1,239 @@
+# src/plugins/word_pulse/db.py
+from __future__ import annotations
+
+import json
+import time
+
+from src.storage import get_db
+
+db = get_db()
+
+SCHEMA_STATEMENTS = [
+    """CREATE TABLE IF NOT EXISTS word_pulse_theme (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(group_id, name)
+    )""",
+    """CREATE TABLE IF NOT EXISTS word_pulse_cluster (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        theme_id INTEGER NOT NULL REFERENCES word_pulse_theme(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE(theme_id, name)
+    )""",
+    """CREATE TABLE IF NOT EXISTS word_pulse_charset (
+        cluster_id INTEGER PRIMARY KEY REFERENCES word_pulse_cluster(id) ON DELETE CASCADE,
+        chars_json TEXT NOT NULL,
+        expanded_at INTEGER NOT NULL
+    )""",
+    """CREATE TABLE IF NOT EXISTS word_pulse_bucket (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        group_id TEXT NOT NULL,
+        theme_id INTEGER NOT NULL REFERENCES word_pulse_theme(id) ON DELETE CASCADE,
+        day TEXT NOT NULL,
+        counts_json TEXT NOT NULL,
+        samples_json TEXT NOT NULL,
+        total_messages INTEGER NOT NULL,
+        sampled INTEGER NOT NULL DEFAULT 0,
+        computed_at INTEGER NOT NULL,
+        UNIQUE(group_id, theme_id, day)
+    )""",
+    "CREATE INDEX IF NOT EXISTS idx_word_pulse_theme_group ON word_pulse_theme(group_id)",
+    "CREATE INDEX IF NOT EXISTS idx_word_pulse_cluster_theme ON word_pulse_cluster(theme_id)",
+    "CREATE INDEX IF NOT EXISTS idx_word_pulse_bucket_lookup ON word_pulse_bucket(group_id, theme_id, day)",
+]
+
+
+def ensure_schema() -> None:
+    db.ensure_schema(SCHEMA_STATEMENTS)
+
+
+# ── Theme ──
+
+
+async def upsert_theme(group_id: str, name: str) -> int:
+    """创建或更新主题。返回 theme_id。"""
+    now = int(time.time())
+    row = await db.fetch_one(
+        "SELECT id FROM word_pulse_theme WHERE group_id = ? AND name = ?",
+        (group_id, name),
+    )
+    if row:
+        await db.execute(
+            "UPDATE word_pulse_theme SET updated_at = ? WHERE id = ?",
+            (now, row["id"]),
+        )
+        return row["id"]
+    await db.execute(
+        "INSERT INTO word_pulse_theme (group_id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        (group_id, name, now, now),
+    )
+    row = await db.fetch_one(
+        "SELECT id FROM word_pulse_theme WHERE group_id = ? AND name = ?",
+        (group_id, name),
+    )
+    assert row is not None
+    return row["id"]
+
+
+async def get_theme(group_id: str, name: str) -> dict | None:
+    """按群+名称查找主题，返回行 dict 或 None。"""
+    row = await db.fetch_one(
+        "SELECT id, group_id, name, created_at, updated_at FROM word_pulse_theme WHERE group_id = ? AND name = ?",
+        (group_id, name),
+    )
+    return None if row is None else dict(row)
+
+
+async def list_themes(group_id: str) -> list[dict]:
+    """列出指定群的所有主题。"""
+    rows = await db.fetch_all(
+        "SELECT id, group_id, name, created_at, updated_at FROM word_pulse_theme WHERE group_id = ? ORDER BY updated_at DESC",
+        (group_id,),
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_theme(theme_id: int) -> None:
+    """删除主题（级联删除 cluster/charset/bucket）。"""
+    await db.execute("DELETE FROM word_pulse_theme WHERE id = ?", (theme_id,))
+
+
+# ── Cluster ──
+
+
+async def replace_clusters(theme_id: int, names: list[str]) -> list[int]:
+    old = await get_clusters(theme_id)
+    old_names = {c["name"]: c["id"] for c in old}
+    new_names = set(names)
+    for c in old:
+        if c["name"] not in new_names:
+            await db.execute("DELETE FROM word_pulse_cluster WHERE id = ?", (c["id"],))
+    now = int(time.time())
+    result_ids: list[int] = []
+    for name in names:
+        if name in old_names:
+            result_ids.append(old_names[name])
+        else:
+            await db.execute(
+                "INSERT INTO word_pulse_cluster (theme_id, name, created_at) VALUES (?, ?, ?)",
+                (theme_id, name, now),
+            )
+            row = await db.fetch_one("SELECT id FROM word_pulse_cluster WHERE theme_id = ? AND name = ?", (theme_id, name))
+            assert row is not None
+            result_ids.append(row["id"])
+    return result_ids
+
+
+async def add_clusters(theme_id: int, names: list[str]) -> list[int]:
+    existing = await get_clusters(theme_id)
+    existing_names = {c["name"] for c in existing}
+    now = int(time.time())
+    new_ids: list[int] = []
+    for name in names:
+        if name in existing_names:
+            continue
+        await db.execute(
+            "INSERT INTO word_pulse_cluster (theme_id, name, created_at) VALUES (?, ?, ?)",
+            (theme_id, name, now),
+        )
+        row = await db.fetch_one("SELECT id FROM word_pulse_cluster WHERE theme_id = ? AND name = ?", (theme_id, name))
+        assert row is not None
+        new_ids.append(row["id"])
+        existing_names.add(name)
+    return new_ids
+
+
+async def get_clusters(theme_id: int) -> list[dict]:
+    rows = await db.fetch_all(
+        "SELECT id, theme_id, name, created_at FROM word_pulse_cluster WHERE theme_id = ? ORDER BY id",
+        (theme_id,),
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_cluster(cluster_id: int) -> None:
+    await db.execute("DELETE FROM word_pulse_cluster WHERE id = ?", (cluster_id,))
+
+
+# ── Charset ──
+
+
+async def save_charsets(theme_id: int, charset_map: dict[str, list[str]]) -> None:
+    clusters = await get_clusters(theme_id)
+    cluster_by_name = {c["name"]: c["id"] for c in clusters}
+    now = int(time.time())
+    for name, chars in charset_map.items():
+        cid = cluster_by_name.get(name)
+        if cid is None:
+            continue
+        await db.execute(
+            """INSERT INTO word_pulse_charset (cluster_id, chars_json, expanded_at)
+               VALUES (?, ?, ?)
+               ON CONFLICT(cluster_id) DO UPDATE SET chars_json=excluded.chars_json, expanded_at=excluded.expanded_at""",
+            (cid, json.dumps(chars, ensure_ascii=False), now),
+        )
+
+
+async def get_expanded_charset(theme_id: int) -> set[str]:
+    rows = await db.fetch_all(
+        """SELECT cs.chars_json FROM word_pulse_charset cs
+           JOIN word_pulse_cluster cl ON cs.cluster_id = cl.id
+           WHERE cl.theme_id = ?""",
+        (theme_id,),
+    )
+    result: set[str] = set()
+    for row in rows:
+        result.update(json.loads(row["chars_json"]))
+    return result
+
+
+# ── Bucket ──
+
+
+async def save_bucket(
+    group_id: str, theme_id: int, day: str,
+    counts_json: str, samples_json: str,
+    total_messages: int, sampled: bool,
+) -> None:
+    now = int(time.time())
+    sampled_int = 1 if sampled else 0
+    await db.execute(
+        """INSERT INTO word_pulse_bucket (group_id, theme_id, day, counts_json, samples_json, total_messages, sampled, computed_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(group_id, theme_id, day) DO UPDATE SET
+               counts_json=excluded.counts_json, samples_json=excluded.samples_json,
+               total_messages=excluded.total_messages, sampled=excluded.sampled, computed_at=excluded.computed_at""",
+        (group_id, theme_id, day, counts_json, samples_json, total_messages, sampled_int, now),
+    )
+
+
+async def get_bucket(group_id: str, theme_id: int, day: str) -> dict | None:
+    row = await db.fetch_one(
+        "SELECT id, group_id, theme_id, day, counts_json, samples_json, total_messages, sampled, computed_at "
+        "FROM word_pulse_bucket WHERE group_id=? AND theme_id=? AND day=?",
+        (group_id, theme_id, day),
+    )
+    return None if row is None else dict(row)
+
+
+async def delete_buckets_by_theme(group_id: str, theme_id: int) -> None:
+    await db.execute("DELETE FROM word_pulse_bucket WHERE group_id=? AND theme_id=?", (group_id, theme_id))
+
+
+async def delete_buckets_older_than(before_day: str) -> int:
+    row = await db.fetch_one("SELECT COUNT(*) AS cnt FROM word_pulse_bucket WHERE day < ?", (before_day,))
+    before = row["cnt"] if row else 0
+    await db.execute("DELETE FROM word_pulse_bucket WHERE day < ?", (before_day,))
+    return before
+
+
+async def get_bucket_days(group_id: str, theme_id: int) -> list[str]:
+    rows = await db.fetch_all(
+        "SELECT day FROM word_pulse_bucket WHERE group_id=? AND theme_id=? ORDER BY day",
+        (group_id, theme_id),
+    )
+    return [r["day"] for r in rows]


### PR DESCRIPTION
## 功能概述

新增 \`word_pulse\` 插件：群管动态注册主题与子类（如炒股 → 抄底/割肉/涨停），用户发 \`总结 N天|周|月 主题\` 即可统计该时间范围内群聊讨论热度分布。

## 核心架构

**注册阶段**（1 次 LLM 调用，批量扩展所有新 cluster 的相关字符集）：
- 群管发 \`词频 add 炒股 抄底 割肉 涨停\`
- AI 一次性扩展每个 cluster 5-30 个语义相关字符（如"割肉"→ 割肉亏损止卖出赔斩仓套牢跌失痛砍断舍离），用于查询时粗过滤
- 字符集只要求"宽"不要求"准"——多扩几个无关字只会让预筛少过滤几条，LLM 兜底不会出错

**查询阶段**（map-reduce，三级预筛降低 LLM 成本）：
- 取时间范围内消息 → 按 SHANGHAI_TZ 拆日桶
- **三级预筛**（0 LLM 调用）：
  - 强预筛：与扩展字符集零交集的消息直接跳过（实测过滤 70-90% 无关消息）
  - 弱预筛：精确命中种子词直接归类（多标签计数）
  - 灰区：有字符重叠但无精确命中 → 送 LLM 批量分类（实测仅占 5-15%）
- **日桶缓存**：历史日永久缓存，今日桶 \`computed_at\` freshness 5 分钟
- 最终 1 次 LLM 汇总：趋势 / 排名 / 典型原文 / 未归类高频词

## 命令

| 命令 | 权限 | 说明 |
|---|---|---|
| \`词频 add 主题 词1 词2...\` | 群管/admin | 创建主题（覆盖式） |
| \`词频 append 主题 词...\` | 群管/admin | 追加子类（仅对新 cluster 扩字符集） |
| \`词频 list\` | 所有人 | 列出本群主题 |
| \`词频 del 主题\` | 群管/admin | 删除主题 |
| \`词频 del 主题 子类\` | 群管/admin | 删除子类 |
| \`词频 refresh 主题\` | 群管/admin | 重新扩展字符集 |
| \`总结 N天\|周\|月 主题\` | 所有人 | 查询热度统计 |

## 复用现有资产

- \`message_archive\`：\`fetch_group_messages_by_time_range\` 取消息
- \`group_permission\`：\`create_group_rule\` per-group 启用控制
- \`sqlite_manager\`：共享异步 SQLite 句柄
- \`a_share_sentiment/ai.py\`：OpenAI 兼容客户端 + 异常分层模板

## 新增 SQLite 表（4 张，均 \`word_pulse_\` 前缀）

- \`word_pulse_theme\`：群 × 主题
- \`word_pulse_cluster\`：主题 × 子类
- \`word_pulse_charset\`：子类 × AI 扩展字符集
- \`word_pulse_bucket\`：(群, 主题, 日) → 分类计数 + 抽样原文（缓存）

## 输出示例

\`\`\`
📊 炒股主题 · 2天 (2026-07-21 ~ 2026-07-22)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
排名  子类     计数   占比
1.   涨停     7      30.4%
2.   割肉     5      21.7%
3.   抄底     2      8.7%
-     其他      4      17%
-     跳过      5
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📈 趋势：涨停热度小幅下滑，割肉情绪明显上升，抄底持续低迷，整体讨论量增加。
💬 典型原文：
  · "昨天那个涨停板真猛" — 老王 2026-07-21
  · "打板失败被套" — 新手 2026-07-21
\`\`\`

## LLM 调用预算

| 场景 | 调用次数 |
|---|---|
| 注册主题（N 个新种子词） | 1 次（批量扩展字符集） |
| 查询 N 天（N≤31） | 0-N 次灰区分类 + 1 次汇总（仅未命中缓存的桶且灰区非空） |
| 今日桶 5 分钟内重查 | 0 次（freshness 缓存命中） |
| 同窗口 5 分钟内重查 | 0 次（result_cache 命中） |

## 配置项（\`.env.prod\`）

\`\`\`bash
word_pulse_plugin_enabled=false       # 全局开关
word_pulse_base_url=...                # OpenAI 兼容 API
word_pulse_api_key=...
word_pulse_model=...
word_pulse_today_bucket_fresh_seconds=300
word_pulse_max_window_days=31
# ...（共 14 个配置项）
\`\`\`

## 兼容性

- 优先尝试 \`response_format: json_schema strict\`（OpenAI 官方 API 支持）
- 若上游 API 返回 400（不支持 strict，如部分 reasoning model 上游）→ 自动降级为 \`response_format: json_object\`，system prompt 已含 schema 形状描述兜底

## 验证

- 已通过 deepseek-v4-flash 真实 API 全链路联调（字符集扩展、灰区分类、汇总）
- 字符集扩展质量高（抄底 23 字、割肉 19 字、涨停 20 字）
- 三级预筛有效（char_pool 从 6 字扩到 57 字后，强预筛精准过滤无关消息）

## 文件变更

7 个文件，1332 行新增：
- \`src/plugins/word_pulse/{__init__,ai,analysis,commands,config,db}.py\`：插件源码
- \`.env.prod\`：配置模板（注释行，不覆盖现有配置）