### PR TITLE
feat(word-pulse): 子类别名支持 + 精简配置

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -182,7 +182,7 @@ NICKNAME=[""]
 
 
 # ========== Word Pulse 词频统计插件配置 ==========
-# 命令：词频 add/append/list/del/refresh, 总结 N天/周/月 主题
+# 命令：词频 add/append/list/del/refresh/alias/unalias, 总结 N天/周/月 主题
 
 # 插件全局开关，默认false
 # word_pulse_plugin_enabled=false
@@ -197,15 +197,7 @@ NICKNAME=[""]
 # word_pulse_api_key=sk-xxxx
 # word_pulse_model=gpt-4.1-mini
 
-# 请求配置
-# word_pulse_timeout_seconds=60
-# word_pulse_temperature=0.0
-# word_pulse_summary_temperature=0.3
-
 # 成本控制
-# word_pulse_cooldown_seconds=30
-# word_pulse_cache_ttl_minutes=5
 # word_pulse_bucket_retention_days=30
 # word_pulse_max_messages_per_bucket=1000
 # word_pulse_max_window_days=31
-# word_pulse_today_bucket_fresh_seconds=300

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -47,6 +47,7 @@ ignore = [
 
 [lint.per-file-ignores]
 "__init__.py" = ["F401"]
+"scripts/**/*.py" = ["PLC0415", "C901", "PLR0912", "PLR0915", "S110"]
 
 # McCabe 复杂度配置
 [lint.mccabe]

--- a/scripts/word_pulse_smoke.py
+++ b/scripts/word_pulse_smoke.py
@@ -1,0 +1,410 @@
+"""word_pulse 本地真实 LLM 联调 smoke 脚本。
+
+用法（不接入真 QQ，用 NoneBug mock bot 模式 + 真实 LLM API）：
+
+    export WORD_PULSE_BASE_URL="https://api.exusiai.top/v1"
+    export WORD_PULSE_API_KEY="sk-..."
+    export WORD_PULSE_MODEL="gpt-4o-mini"   # 或其他 OpenAI 兼容模型
+    uv run python scripts/word_pulse_smoke.py
+
+验证内容：
+  1. 注册主题 → 真实 LLM 字符集扩展（看字符是否相关、schema strict 是否被接受）
+  2. 预筛真实感群消息（看强/弱/灰区分布）
+  3. 灰区批量分类 → 真实 LLM 分类（看准确率）
+  4. 汇总 → 真实 LLM 总结（看 trend/examples 质量）
+  5. 完整渲染输出（人工检视可读性）
+
+所有数据在临时 SQLite 里，跑完即弃，不影响真实 message_archive。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# 把项目根加入 sys.path（让 `from src.plugins...` 能 import）
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# 必须在 import nonebot 前设置 KIANA_DB_PATH，让 get_db() 指向临时库
+_TMP_DB = Path(tempfile.gettempdir()) / "word_pulse_smoke.sqlite3"
+os.environ["KIANA_DB_PATH"] = str(_TMP_DB)
+for suffix in ("", "-shm", "-wal"):
+    Path(f"{_TMP_DB}{suffix}").unlink(missing_ok=True)
+
+
+def _check_env() -> tuple[str, str, str]:
+    base = os.environ.get("WORD_PULSE_BASE_URL", "").rstrip("/")
+    key = os.environ.get("WORD_PULSE_API_KEY", "")
+    model = os.environ.get("WORD_PULSE_MODEL", "")
+    missing = [n for n, v in [("WORD_PULSE_BASE_URL", base), ("WORD_PULSE_API_KEY", key), ("WORD_PULSE_MODEL", model)] if not v]
+    if missing:
+        print(f"❌ 缺少环境变量: {', '.join(missing)}", file=sys.stderr)
+        print("示例:", file=sys.stderr)
+        print("  export WORD_PULSE_BASE_URL='https://api.exusiai.top/v1'", file=sys.stderr)
+        print("  export WORD_PULSE_API_KEY='sk-...'", file=sys.stderr)
+        print("  export WORD_PULSE_MODEL='gpt-4o-mini'", file=sys.stderr)
+        sys.exit(1)
+    if not base.endswith("/v1"):
+        print(f"⚠ base_url 似乎不以 /v1 结尾: {base}（脚本会自动补 /chat/completions）", file=sys.stderr)
+    return base, key, model
+
+
+# ── 真实感测试消息（覆盖三类：精确命中、灰区、无关）──────────────────────────
+
+SHANGHAI_TZ = ZoneInfo("Asia/Shanghai")
+
+
+def _ts(days_ago: int, hour: int, minute: int = 0) -> int:
+    """构造相对今天 days_ago 天前 hour:minute 的 epoch 秒（SHANGHAI_TZ）。"""
+    now = datetime.now(SHANGHAI_TZ)
+    target = now - timedelta(days=days_ago)
+    dt = target.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    return int(dt.timestamp())
+
+
+# 群消息样本：每条 (user_id, sender_name, plain_text, days_ago, hour)
+# 故意覆盖炒股主题下的多种表达方式
+SAMPLE_MESSAGES: list[tuple[int, str, str, int, int]] = [
+    # ── 精确命中"涨停"（弱预筛直接归类）──
+    (1001, "股神A", "今天又涨停了哈哈哈", 0, 10),
+    (1002, "小韭菜", "涨停涨停涨停！发财了", 0, 14),
+    (1003, "老王", "昨天那个涨停板真猛", 1, 9),
+    (1004, "路人甲", "这波涨停能持续吗", 1, 20),
+
+    # ── 精确命中"割肉" ──
+    (1005, "亏成狗", "今天割肉了，亏死了", 0, 11),
+    (1006, "绝望哥", "割肉跑路再见股市", 0, 15),
+    (1007, "菜鸡", "昨天没割肉今天更亏", 1, 10),
+
+    # ── 精确命中"抄底" ──
+    (1008, "胆大", "抄底抄底！现在就是底", 0, 13),
+    (1009, "乐观姐", "我准备抄底了", 1, 14),
+
+    # ── 灰区：含相关字符（亏/跌/涨/板）但无精确种子词 ──
+    (1010, "郁闷哥", "今天亏爆了，心态崩了", 0, 14),       # 含"亏"
+    (1011, "老张", "跌妈不认，这行情真没法玩", 0, 15),       # 含"跌"
+    (1012, "吃瓜", "一字板根本买不到", 1, 10),               # 含"板"
+    (1013, "新手", "打板失败被套", 1, 11),                   # 含"板"
+    (1014, "佛系", "又亏了3个点，习惯就好", 1, 14),           # 含"亏"
+    (1015, "股市老炮", "连板5天太强了", 0, 9),               # 含"板"
+    (1016, "贪心", "涨太高了不敢追", 0, 16),                 # 含"涨"
+    (1017, "稳健", "今天加仓了点", 1, 13),                   # 含"加"... 可能在"抄底"扩展字符集里
+
+    # ── 无关（强预筛应跳过）──
+    (1018, "吃货", "中午吃啥", 0, 12),
+    (1019, "上班族", "今天好困啊", 0, 9),
+    (1020, "摸鱼王", "下班了下班了", 0, 18),
+    (1021, "游戏宅", "晚上开黑吗", 1, 19),
+    (1022, "健身狗", "刚跑完5公里", 0, 7),
+    (1023, "铲屎官", "我家猫又吐毛球了", 1, 8),
+]
+
+
+async def _init_nonebot(base_url: str, api_key: str, model: str) -> None:
+    """初始化 NoneBot 并加载 word_pulse + message_archive 插件。"""
+    import nonebot
+    from nonebot.adapters.onebot.v11 import Adapter as ONEBOT_V11Adapter
+
+    nonebot.init(
+        driver="~fastapi",
+        word_pulse_plugin_enabled=True,
+        word_pulse_base_url=base_url,
+        word_pulse_api_key=api_key,
+        word_pulse_model=model,
+        word_pulse_group_mode="all",
+        superusers=["999"],
+    )
+    driver = nonebot.get_driver()
+    driver.register_adapter(ONEBOT_V11Adapter)
+    nonebot.load_plugin("src.plugins.message_archive")
+    nonebot.load_plugin("src.plugins.word_pulse")
+
+
+async def _seed_messages(group_id: int = 654321) -> int:
+    """把 SAMPLE_MESSAGES 写入 message_archive 表。"""
+    from nonebot.adapters.onebot.v11 import GroupMessageEvent, Message
+    from nonebot.adapters.onebot.v11.event import Sender
+
+    from src.plugins.message_archive.db import archive_message_event, ensure_schema
+
+    # driver.on_startup 在脚本里不会自动触发，手动建表
+    ensure_schema()
+
+    count = 0
+    for i, (uid, name, text, days_ago, hour) in enumerate(SAMPLE_MESSAGES):
+        ev = GroupMessageEvent(
+            time=_ts(days_ago, hour),
+            self_id=987654321,
+            post_type="message",
+            sub_type="normal",
+            user_id=uid,
+            message_type="group",
+            group_id=group_id,
+            message_id=5000 + i,
+            message=Message(text),
+            original_message=Message(text),
+            raw_message=text,
+            font=0,
+            sender=Sender(user_id=uid, nickname=name, card=name, role="member"),
+        )
+        await archive_message_event(ev)
+        count += 1
+    return count
+
+
+async def _run_pipeline(group_id: int = 654321) -> None:
+    """端到端跑：注册主题 → 预筛分析 → 灰区 LLM 分类 → 汇总。"""
+    from src.plugins.message_archive.db import fetch_group_messages_by_time_range
+    from src.plugins.word_pulse import config
+    from src.plugins.word_pulse.ai import classify_batch, expand_charsets, summarize
+    from src.plugins.word_pulse.analysis import (
+        build_summary_prompt,
+        classify_message,
+        compute_or_load_buckets,
+    )
+    from src.plugins.word_pulse.config import (
+        CLASSIFY_TEMPERATURE,
+        MAX_EXAMPLES_IN_SUMMARY,
+        REQUEST_TIMEOUT_SECONDS,
+        SUMMARY_TEMPERATURE,
+        TODAY_BUCKET_FRESH_SECONDS,
+    )
+    from src.plugins.word_pulse.db import (
+        ensure_schema,
+        get_clusters,
+        get_expanded_charset,
+        replace_clusters,
+        save_charsets,
+        upsert_theme,
+    )
+
+    ensure_schema()
+
+    # ── Step 1: 注册主题 + 真实字符集扩展 ──────────────────────────────
+    print("\n" + "=" * 70)
+    print("Step 1: 注册主题「炒股」并真实扩展字符集")
+    print("=" * 70)
+    theme_name = "炒股"
+    seeds = ["抄底", "割肉", "涨停"]
+    tid = await upsert_theme(str(group_id), theme_name)
+    await replace_clusters(tid, seeds)
+    print(f"  主题已创建 (theme_id={tid}), seeds={seeds}")
+    print(f"  调用 LLM 扩展字符集 (model={config.word_pulse_model})...")
+
+    try:
+        charsets = await expand_charsets(
+            base_url=config.word_pulse_base_url,
+            api_key=config.word_pulse_api_key,
+            model=config.word_pulse_model,
+            seeds=seeds,
+            theme=theme_name,
+            temperature=CLASSIFY_TEMPERATURE,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except Exception as e:
+        print(f"  ❌ 字符集扩展失败: {type(e).__name__}: {e}")
+        print("  后续步骤会用空字符集降级（只靠种子词字符预筛）")
+        charsets = {}
+    else:
+        await save_charsets(tid, charsets)
+        print("  ✓ 字符集扩展成功:")
+        for cl, chars in charsets.items():
+            print(f"    {cl}: {chars}")
+
+    # ── Step 2: 预筛分析（不调 LLM）──────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Step 2: 三级预筛分析（0 LLM 调用）")
+    print("=" * 70)
+
+    # 取今天 + 昨天 的消息
+    now_dt = datetime.now(SHANGHAI_TZ)
+    today_start = int(datetime.combine(now_dt.date(), __import__("datetime").time.min, SHANGHAI_TZ).timestamp())
+    yesterday_start = today_start - 86400
+    today_end = today_start + 86400
+
+    msgs_today = await fetch_group_messages_by_time_range(str(group_id), today_start, today_end)
+    msgs_yesterday = await fetch_group_messages_by_time_range(str(group_id), yesterday_start, today_start)
+    all_msgs = msgs_yesterday + msgs_today
+    print(f"  取到 {len(msgs_yesterday)} 条昨日 + {len(msgs_today)} 条今日 = {len(all_msgs)} 条消息")
+
+    # 构建 char_pool
+    clusters = await get_clusters(tid)
+    cluster_names = [c["name"] for c in clusters]
+    seed_chars = set("".join(cluster_names))
+    expanded = await get_expanded_charset(tid)
+    char_pool = seed_chars | expanded
+    cluster_terms = {n: {n} for n in cluster_names}
+    print(f"  char_pool ({len(char_pool)} 字): {''.join(sorted(char_pool))}")
+
+    direct: list[tuple[int, list[str]]] = []
+    grey: list[tuple[int, str]] = []
+    skipped: list[tuple[int, str]] = []
+    for m in all_msgs:
+        r = classify_message(m.plain_text, char_pool, cluster_terms)
+        if r is None:
+            skipped.append((m.id, m.plain_text))
+        elif r == "GREY":
+            grey.append((m.id, m.plain_text))
+        else:
+            direct.append((m.id, r))
+
+    print("\n  📊 预筛分布:")
+    print(f"    强预筛跳过（无关）: {len(skipped)} 条")
+    for mid, txt in skipped[:5]:
+        print(f"      [{mid}] {txt}")
+    if len(skipped) > 5:
+        print(f"      ... (共 {len(skipped)} 条)")
+
+    print(f"\n    弱预筛直接归类（精确命中）: {len(direct)} 条")
+    for mid, cls in direct:
+        txt = next((m.plain_text for m in all_msgs if m.id == mid), "?")
+        print(f"      [{mid}] {txt}  →  {cls}")
+
+    print(f"\n    灰区（送 LLM 分类）: {len(grey)} 条")
+    for mid, txt in grey:
+        print(f"      [{mid}] {txt}")
+
+    # ── Step 3: 灰区真实 LLM 分类 ────────────────────────────────────
+    if grey:
+        print("\n" + "=" * 70)
+        print(f"Step 3: 灰区 {len(grey)} 条 → 真实 LLM 批量分类")
+        print("=" * 70)
+        try:
+            grey_results = await classify_batch(
+                base_url=config.word_pulse_base_url,
+                api_key=config.word_pulse_api_key,
+                model=config.word_pulse_model,
+                messages=grey,
+                clusters=[{"id": i, "name": n} for i, n in enumerate(cluster_names)],
+                theme_name=theme_name,
+                temperature=CLASSIFY_TEMPERATURE,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except Exception as e:
+            print(f"  ❌ 灰区分类失败: {type(e).__name__}: {e}")
+            grey_results = [(mid, None) for mid, _ in grey]
+        else:
+            print("  ✓ LLM 分类结果:")
+            for mid, cl in grey_results:
+                txt = next((m.plain_text for m in all_msgs if m.id == mid), "?")
+                marker = "✓" if cl else "✗"
+                print(f"    {marker} [{mid}] {txt}  →  {cl or '(null 不归类)'}")
+    else:
+        grey_results = []
+        print("\n  ℹ 无灰区消息需要 LLM 分类")
+
+    # ── Step 4: 通过 compute_or_load_buckets 跑完整日桶计算 ──────────
+    print("\n" + "=" * 70)
+    print("Step 4: compute_or_load_buckets 完整日桶计算（2 天）")
+    print("=" * 70)
+    buckets = await compute_or_load_buckets(
+        group_id=str(group_id), theme_id=tid, theme_name=theme_name,
+        clusters=[{"id": i, "name": n} for i, n in enumerate(cluster_names)],
+        char_pool=char_pool, cluster_terms=cluster_terms,
+        day_range=2,
+        base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
+        model=config.word_pulse_model,
+        max_messages_per_bucket=config.word_pulse_max_messages_per_bucket,
+        max_sample_per_cluster=config.word_pulse_max_sample_per_cluster,
+        temperature=CLASSIFY_TEMPERATURE,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+        today_bucket_fresh_seconds=TODAY_BUCKET_FRESH_SECONDS,
+    )
+    for b in buckets:
+        sampled_tag = " (sampled)" if b.get("sampled") else ""
+        print(f"\n  [{b['day']}] 总 {b['total_messages']} 条{sampled_tag}")
+        for k, v in sorted(b["counts"].items()):
+            print(f"    {k}: {v}")
+        if b["samples"]:
+            print("    抽样原文:")
+            for s in b["samples"][:3]:
+                print(f"      · {s['author']}: {s['text']} (→ {s['cluster']})")
+
+    # ── Step 5: 真实 LLM 汇总 + 渲染 ─────────────────────────────────
+    print("\n" + "=" * 70)
+    print("Step 5: 真实 LLM 汇总 + 完整渲染")
+    print("=" * 70)
+
+    start = (now_dt - timedelta(days=1)).strftime("%Y-%m-%d")
+    end = now_dt.strftime("%Y-%m-%d")
+    window_desc = f"2天 ({start} ~ {end})"
+    prompt = build_summary_prompt(
+        theme_name=theme_name,
+        clusters=[{"name": n} for n in cluster_names],
+        buckets=buckets,
+        window_meta=window_desc,
+        max_examples=MAX_EXAMPLES_IN_SUMMARY,
+    )
+    print("\n  ───── 送给 LLM 的 prompt ─────")
+    print(prompt)
+    print("  ────────────────────────────────")
+
+    try:
+        summary = await summarize(
+            base_url=config.word_pulse_base_url,
+            api_key=config.word_pulse_api_key,
+            model=config.word_pulse_model,
+            prompt=prompt,
+            temperature=SUMMARY_TEMPERATURE,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except Exception as e:
+        print(f"\n  ❌ 汇总失败: {type(e).__name__}: {e}")
+        return
+
+    print("\n  ✓ LLM 返回:")
+    print(f"    trend: {summary.trend}")
+    print("    ranking:")
+    for r in summary.ranking:
+        print(f"      {r.cluster}: {r.count} ({r.percent}%)")
+    print("    examples:")
+    for ex in summary.examples:
+        print(f"      [{ex.day}] {ex.author}: {ex.text} (→ {ex.cluster})")
+    if summary.unclassified_high_freq:
+        print("    unclassified_high_freq:")
+        for t in summary.unclassified_high_freq:
+            print(f"      {t.term}: {t.count}")
+
+    # ── Step 6: 完整渲染输出（模拟用户看到的）────────────────────────
+    print("\n" + "=" * 70)
+    print("Step 6: 用户最终看到的渲染输出")
+    print("=" * 70)
+    from src.plugins.word_pulse import _render_summary
+    rendered = _render_summary(theme_name, window_desc, buckets, summary)
+    print()
+    print(rendered)
+    print()
+
+
+async def main() -> None:
+    base, key, model = _check_env()
+    print("🚀 word_pulse smoke 联调")
+    print(f"   base_url: {base}")
+    print(f"   model:    {model}")
+    print(f"   db:       {_TMP_DB}")
+    print(f"   样本消息: {len(SAMPLE_MESSAGES)} 条（今日 + 昨日）")
+
+    await _init_nonebot(base, key, model)
+    seeded = await _seed_messages()
+    print(f"   已写入 message_archive: {seeded} 条")
+
+    await _run_pipeline()
+
+    # 清理临时 db
+    try:
+        from src.storage import get_db
+        await get_db().close()
+    except Exception:
+        pass
+    print("\n✅ smoke 完成。临时 db 在", _TMP_DB)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/plugins/word_pulse/__init__.py
+++ b/src/plugins/word_pulse/__init__.py
@@ -24,8 +24,18 @@ from .ai import (
 )
 from .analysis import build_summary_prompt, compute_or_load_buckets
 from .commands import parse_command, parse_query, resolve_window_days
-from .config import Config
+from .config import (
+    CLASSIFY_TEMPERATURE,
+    MAX_EXAMPLES_IN_SUMMARY,
+    QUERY_COOLDOWN_SECONDS,
+    REQUEST_TIMEOUT_SECONDS,
+    RESULT_CACHE_TTL_SECONDS,
+    SUMMARY_TEMPERATURE,
+    TODAY_BUCKET_FRESH_SECONDS,
+    Config,
+)
 from .db import (
+    add_cluster_aliases,
     add_clusters,
     delete_buckets_by_theme,
     delete_cluster,
@@ -36,6 +46,7 @@ from .db import (
     get_expanded_charset,
     get_theme,
     list_themes,
+    remove_cluster_aliases,
     replace_clusters,
     save_charsets,
     upsert_theme,
@@ -55,6 +66,8 @@ __plugin_meta__ = PluginMetadata(
         "词频 del 主题 —— 删除主题\n"
         "词频 del 主题 子类 —— 删除子类\n"
         "词频 refresh 主题 —— 刷新字符集\n"
+        "词频 alias 主题 主名词 别名1 别名2... —— 给子类添加别名\n"
+        "词频 unalias 主题 主名词 别名1... —— 删除子类别名\n"
         "总结 N天/周/月 主题 —— 查询热度统计"
     ),
     config=Config,
@@ -77,7 +90,10 @@ word_pulse_rule = create_group_rule(lambda: config, "word_pulse_plugin_enabled",
 
 # ── Matchers ──
 
-admin_matcher = on_regex(r"^词频\s+(add|append|list|del|refresh)\b.*", rule=word_pulse_rule, priority=5, block=True)
+admin_matcher = on_regex(
+    r"^词频\s+(add|append|list|del|refresh|alias|unalias)\b.*",
+    rule=word_pulse_rule, priority=5, block=True,
+)
 query_matcher = on_regex(r"^总结\s+\d+\s*(天|d|周|w|月|m)\s+\S+", rule=word_pulse_rule, priority=5, block=True)
 
 # ── Cooldown & Cache ──
@@ -92,7 +108,7 @@ class CachedResult:
 
 
 result_cache: dict[str, CachedResult] = {}
-_cache_ttl = config.word_pulse_cache_ttl_minutes * 60
+_cache_ttl = RESULT_CACHE_TTL_SECONDS
 
 
 def _cache_key(gid: int, theme: str, sig: str) -> str:
@@ -116,7 +132,7 @@ def _cooldown_remaining(gid: int) -> int:
     last = cooldown_dict.get(str(gid))
     if last is None:
         return 0
-    return max(0, int(last + config.word_pulse_cooldown_seconds - time.time()))
+    return max(0, int(last + QUERY_COOLDOWN_SECONDS - time.time()))
 
 
 def _mark_cooldown(gid: int) -> None:
@@ -154,7 +170,7 @@ async def _run_expand_or_degrade(*, theme_id: int, seeds: list[str], theme_name:
         charsets = await expand_charsets(
             base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
             model=config.word_pulse_model, seeds=seeds, theme=theme_name,
-            temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
+            temperature=CLASSIFY_TEMPERATURE, timeout=REQUEST_TIMEOUT_SECONDS,
         )
         await save_charsets(theme_id, charsets)
         await delete_buckets_by_theme(gid, theme_id)
@@ -180,6 +196,7 @@ async def handle_admin(event: MessageEvent) -> None:
     handlers = {
         "add": _handle_add, "append": _handle_append, "list": _handle_list,
         "del": _handle_del, "refresh": _handle_refresh,
+        "alias": _handle_alias, "unalias": _handle_unalias,
     }
     try:
         await handlers[cmd.action](ge, cmd)
@@ -217,7 +234,7 @@ async def _handle_append(event: GroupMessageEvent, cmd) -> None:
         charsets = await expand_charsets(
             base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
             model=config.word_pulse_model, seeds=new_seeds, theme=cmd.theme,
-            temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
+            temperature=CLASSIFY_TEMPERATURE, timeout=REQUEST_TIMEOUT_SECONDS,
         )
         await save_charsets(theme["id"], charsets)
     except WordPulseAIError as e:
@@ -234,8 +251,15 @@ async def _handle_list(event: GroupMessageEvent, _cmd=None) -> None:
     lines = ["📊 本群主题列表："]
     for t in themes:
         cls = await get_clusters(t["id"])
-        seeds = "、".join(c["name"] for c in cls) or "（无子类）"
-        lines.append(f"  · {t['name']} — {seeds}")
+        if not cls:
+            lines.append(f"  · {t['name']} — （无子类）")
+            continue
+        for c in cls:
+            aliases = c.get("aliases") or []
+            if aliases:
+                lines.append(f"  · {t['name']} / {c['name']}（别名: {'、'.join(aliases)}）")
+            else:
+                lines.append(f"  · {t['name']} / {c['name']}")
     await admin_matcher.finish("\n".join(lines))
 
 
@@ -275,6 +299,54 @@ async def _handle_refresh(event: GroupMessageEvent, cmd) -> None:
     await admin_matcher.finish(f"✓ 主题「{cmd.theme}」字符集已刷新（{len(seeds)} 个子类）\n  子类：{'、'.join(seeds)}")
 
 
+async def _handle_alias(event: GroupMessageEvent, cmd) -> None:
+    """词频 alias 主题 主名词 别名... —— 给子类批量添加别名。
+
+    cmd.seeds[0] = 主名词，cmd.seeds[1:] = 别名列表。
+    """
+    theme = await get_theme(str(event.group_id), cmd.theme)
+    if theme is None:
+        await admin_matcher.finish(f"本群尚未创建主题「{cmd.theme}」")
+        return
+    main_name, aliases = cmd.seeds[0], cmd.seeds[1:]
+    cls = await get_clusters(theme["id"])
+    target = [c for c in cls if c["name"] == main_name]
+    if not target:
+        await admin_matcher.finish(f"主题「{cmd.theme}」中没有子类「{main_name}」")
+        return
+    added = await add_cluster_aliases(target[0]["id"], aliases, theme_id=theme["id"])
+    # alias 变了，旧的日桶归类已过期，清掉让其重算
+    await delete_buckets_by_theme(str(event.group_id), theme["id"])
+    if not added:
+        await admin_matcher.finish(
+            f"未新增别名（全部为重复或与现有子类名冲突）：{'、'.join(aliases)}"
+        )
+        return
+    await admin_matcher.finish(
+        f"✓ 已为「{main_name}」添加别名：{'、'.join(added)}"
+    )
+
+
+async def _handle_unalias(event: GroupMessageEvent, cmd) -> None:
+    """词频 unalias 主题 主名词 别名... —— 删除子类别名。"""
+    theme = await get_theme(str(event.group_id), cmd.theme)
+    if theme is None:
+        await admin_matcher.finish(f"本群尚未创建主题「{cmd.theme}」")
+        return
+    main_name, aliases = cmd.seeds[0], cmd.seeds[1:]
+    cls = await get_clusters(theme["id"])
+    target = [c for c in cls if c["name"] == main_name]
+    if not target:
+        await admin_matcher.finish(f"主题「{cmd.theme}」中没有子类「{main_name}」")
+        return
+    removed = await remove_cluster_aliases(target[0]["id"], aliases)
+    await delete_buckets_by_theme(str(event.group_id), theme["id"])
+    if not removed:
+        await admin_matcher.finish(f"未删除任何别名（不存在的别名被忽略）：{'、'.join(aliases)}")
+        return
+    await admin_matcher.finish(f"✓ 已从「{main_name}」删除别名：{'、'.join(removed)}")
+
+
 # ── Query handler ──
 
 
@@ -296,13 +368,13 @@ async def _resolve_query_target(ge: GroupMessageEvent, query) -> tuple[dict, lis
 async def _run_summary(*, query, theme: dict, clusters: list[dict], buckets: list[dict], window_desc: str) -> str:
     prompt = build_summary_prompt(
         theme_name=query.theme, clusters=clusters, buckets=buckets,
-        window_meta=window_desc, max_examples=config.word_pulse_max_examples_in_summary,
+        window_meta=window_desc, max_examples=MAX_EXAMPLES_IN_SUMMARY,
     )
     try:
         summary = await summarize(
             base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key,
             model=config.word_pulse_model, prompt=prompt,
-            temperature=config.word_pulse_summary_temperature, timeout=config.word_pulse_timeout_seconds,
+            temperature=SUMMARY_TEMPERATURE, timeout=REQUEST_TIMEOUT_SECONDS,
         )
     except WordPulseAITimeoutError:
         return "AI 总结超时，请稍后重试"
@@ -357,17 +429,27 @@ async def handle_query(event: MessageEvent) -> None:
 
 async def _compute_buckets(ge: GroupMessageEvent, query, theme: dict, clusters: list[dict], total_days: int) -> list[dict]:
     seed_chars = set("".join(c["name"] for c in clusters))
+    # 主名词 + 别名 都参与粗筛字符池（别名里的字也算相关字）
+    alias_chars = set("".join("".join(c.get("aliases") or []) for c in clusters))
     expanded = await get_expanded_charset(theme["id"])
-    char_pool = seed_chars | expanded
-    cluster_terms = {c["name"]: {c["name"]} for c in clusters}
+    char_pool = seed_chars | alias_chars | expanded
+    # 关键：cluster_terms 把别名并入主名词，使别名消息在弱预筛阶段就被正确归类
+    cluster_terms = {
+        c["name"]: {c["name"], *(c.get("aliases") or [])} for c in clusters
+    }
+    # 给 GREY 阶段 classify_batch 用的 cluster 结构必须含 aliases
+    clusters_for_classify = [
+        {"name": c["name"], "aliases": c.get("aliases") or []} for c in clusters
+    ]
     return await compute_or_load_buckets(
-        group_id=str(ge.group_id), theme_id=theme["id"], theme_name=query.theme, clusters=clusters,
-        char_pool=char_pool, cluster_terms=cluster_terms, day_range=total_days,
+        group_id=str(ge.group_id), theme_id=theme["id"], theme_name=query.theme,
+        clusters=clusters_for_classify, char_pool=char_pool, cluster_terms=cluster_terms,
+        day_range=total_days,
         base_url=config.word_pulse_base_url, api_key=config.word_pulse_api_key, model=config.word_pulse_model,
         max_messages_per_bucket=config.word_pulse_max_messages_per_bucket,
         max_sample_per_cluster=config.word_pulse_max_sample_per_cluster,
-        temperature=config.word_pulse_temperature, timeout=config.word_pulse_timeout_seconds,
-        today_bucket_fresh_seconds=config.word_pulse_today_bucket_fresh_seconds,
+        temperature=CLASSIFY_TEMPERATURE, timeout=REQUEST_TIMEOUT_SECONDS,
+        today_bucket_fresh_seconds=TODAY_BUCKET_FRESH_SECONDS,
     )
 
 

--- a/src/plugins/word_pulse/ai.py
+++ b/src/plugins/word_pulse/ai.py
@@ -241,6 +241,8 @@ _BATCH_CLASSIFY_SCHEMA = {
 _BATCH_SYSTEM = (
     "你是中文群聊话题分类助手。给定主题与子类簇定义，"
     "把每条消息归到一个最匹配的子类或 null（表示不属于该主题）。\n"
+    "子类描述中若带「别名:」后缀，表示该子类同时匹配这些别名表达，"
+    "归到该子类时按等同语义处理。\n"
     "必须返回严格 JSON，schema 形如：\n"
     '{"results": [{"id": <消息id>, "cluster": "子类名" 或 null}]}\n'
     "results 数组必须为每条输入消息返回一个条目，id 与输入消息的 [id] 对应。"
@@ -254,7 +256,10 @@ async def classify_batch(
 ) -> list[tuple[int, str | None]]:
     if not messages:
         return []
-    cluster_lines = "\n".join(f"- {c['name']}" for c in clusters)
+    cluster_lines = "\n".join(
+        f"- {c['name']}" + (f" (别名: {', '.join(c['aliases'])})" if c.get('aliases') else "")
+        for c in clusters
+    )
     all_results: list[tuple[int, str | None]] = []
     for start in range(0, len(messages), max_batch_size):
         chunk = messages[start:start + max_batch_size]

--- a/src/plugins/word_pulse/commands.py
+++ b/src/plugins/word_pulse/commands.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class ParsedCommand:
-    action: str  # add / append / list / del / refresh
+    action: str  # add / append / list / del / refresh / alias / unalias
     theme: str | None = None
     seeds: list[str] | None = None
 
@@ -27,16 +27,28 @@ _CMD_LIST = re.compile(rf"^{_PREFIX}\s+list$")
 _CMD_DEL_CLUSTER = re.compile(rf"^{_PREFIX}\s+del\s+(\S+)\s+(\S+)$")
 _CMD_DEL_THEME = re.compile(rf"^{_PREFIX}\s+del\s+(\S+)$")
 _CMD_REFRESH = re.compile(rf"^{_PREFIX}\s+refresh\s+(\S+)$")
+# alias / unalias: 主题 主名词 别名1 [别名2 ...] —— 至少 3 个 token（含命令字）
+_CMD_ALIAS = re.compile(rf"^{_PREFIX}\s+alias\s+(\S+)\s+(\S+)\s+(.+)$")
+_CMD_UNALIAS = re.compile(rf"^{_PREFIX}\s+unalias\s+(\S+)\s+(\S+)\s+(.+)$")
 _QUERY_RE = re.compile(rf"^{_QUERY_P}\s+(\d+)\s*(天|d|周|w|月|m)\s+(\S+)$")
 
 
-def parse_command(text: str) -> ParsedCommand | None:
+def parse_command(text: str) -> ParsedCommand | None:  # noqa: PLR0911
     m = _CMD_DEL_CLUSTER.match(text)
     if m:
         return ParsedCommand(action="del", theme=m.group(1), seeds=[m.group(2)])
     m = _CMD_DEL_THEME.match(text)
     if m:
         return ParsedCommand(action="del", theme=m.group(1))
+    m = _CMD_ALIAS.match(text)
+    if m:
+        # 主名词 + 至少一个别名
+        aliases = [s for s in re.split(r"\s+", m.group(3).strip()) if s]
+        return ParsedCommand(action="alias", theme=m.group(1), seeds=[m.group(2), *aliases])
+    m = _CMD_UNALIAS.match(text)
+    if m:
+        aliases = [s for s in re.split(r"\s+", m.group(3).strip()) if s]
+        return ParsedCommand(action="unalias", theme=m.group(1), seeds=[m.group(2), *aliases])
     m = _CMD_ADD.match(text)
     if m:
         seeds = [s for s in re.split(r"\s+", m.group(2).strip()) if s]

--- a/src/plugins/word_pulse/config.py
+++ b/src/plugins/word_pulse/config.py
@@ -3,20 +3,22 @@ from pydantic import BaseModel, Field
 
 from src.plugins.group_permission import GroupPermissionMixin
 
+# ── 不可调常量（细枝末节，硬编码避免污染配置）──
+CLASSIFY_TEMPERATURE: float = 0.0       # 字符集扩展 + 灰区分类
+SUMMARY_TEMPERATURE: float = 0.3        # 最终热度总结
+REQUEST_TIMEOUT_SECONDS: float = 60.0   # 单次 AI 请求超时
+QUERY_COOLDOWN_SECONDS: int = 30        # 同群查询冷却
+RESULT_CACHE_TTL_SECONDS: int = 300     # 结果缓存 TTL（5 分钟）
+TODAY_BUCKET_FRESH_SECONDS: int = 300   # 今日桶 freshness 窗口
+MAX_EXAMPLES_IN_SUMMARY: int = 5        # 总结里典型原文条数
+
 
 class Config(GroupPermissionMixin, BaseModel):
     word_pulse_plugin_enabled: bool = Field(default=False, description="是否启用词频统计插件")
     word_pulse_base_url: str = Field(default="", description="OpenAI 兼容接口的 Base URL")
     word_pulse_api_key: str = Field(default="", description="OpenAI 兼容接口的 API Key")
     word_pulse_model: str = Field(default="", description="OpenAI 兼容接口的模型名称")
-    word_pulse_temperature: float = Field(default=0.0, ge=0, le=2, description="分类温度")
-    word_pulse_summary_temperature: float = Field(default=0.3, ge=0, le=2, description="汇总温度")
-    word_pulse_timeout_seconds: float = Field(default=60.0, gt=0, le=300, description="AI请求超时")
-    word_pulse_cooldown_seconds: int = Field(default=30, ge=0, le=3600, description="查询冷却秒数")
-    word_pulse_cache_ttl_minutes: int = Field(default=5, ge=1, le=1440, description="结果缓存分钟")
     word_pulse_bucket_retention_days: int = Field(default=30, ge=1, le=365, description="桶保留天数")
     word_pulse_max_messages_per_bucket: int = Field(default=1000, ge=100, le=10000, description="单桶消息上限")
     word_pulse_max_sample_per_cluster: int = Field(default=3, ge=1, le=10, description="每cluster抽样条数")
-    word_pulse_max_examples_in_summary: int = Field(default=5, ge=1, le=20, description="总结中原文条数")
     word_pulse_max_window_days: int = Field(default=31, ge=1, le=365, description="查询窗口上限天")
-    word_pulse_today_bucket_fresh_seconds: int = Field(default=300, ge=60, le=3600, description="今日桶 freshness 窗口秒数")

--- a/src/plugins/word_pulse/db.py
+++ b/src/plugins/word_pulse/db.py
@@ -49,6 +49,19 @@ SCHEMA_STATEMENTS = [
 
 def ensure_schema() -> None:
     db.ensure_schema(SCHEMA_STATEMENTS)
+    _ensure_aliases_column()
+
+
+def _ensure_aliases_column() -> None:
+    """为旧库补齐 word_pulse_cluster.aliases_json 列。
+
+    SQLite 不支持 ADD COLUMN IF NOT EXISTS，用 PRAGMA 检测后补列。
+    """
+    cols = {row[1] for row in db._conn.execute("PRAGMA table_info(word_pulse_cluster)").fetchall()}
+    if "aliases_json" not in cols:
+        db._conn.execute(
+            "ALTER TABLE word_pulse_cluster ADD COLUMN aliases_json TEXT NOT NULL DEFAULT '[]'"
+        )
 
 
 # ── Theme ──
@@ -149,14 +162,121 @@ async def add_clusters(theme_id: int, names: list[str]) -> list[int]:
 
 async def get_clusters(theme_id: int) -> list[dict]:
     rows = await db.fetch_all(
-        "SELECT id, theme_id, name, created_at FROM word_pulse_cluster WHERE theme_id = ? ORDER BY id",
+        "SELECT id, theme_id, name, created_at, aliases_json FROM word_pulse_cluster WHERE theme_id = ? ORDER BY id",
         (theme_id,),
     )
-    return [dict(r) for r in rows]
+    result: list[dict] = []
+    for r in rows:
+        d = dict(r)
+        try:
+            d["aliases"] = json.loads(d.pop("aliases_json", "[]"))
+        except (json.JSONDecodeError, KeyError):
+            d["aliases"] = []
+        result.append(d)
+    return result
 
 
 async def delete_cluster(cluster_id: int) -> None:
     await db.execute("DELETE FROM word_pulse_cluster WHERE id = ?", (cluster_id,))
+
+
+# ── Cluster aliases ──
+
+
+async def add_cluster_aliases(
+    cluster_id: int, aliases: list[str], *, theme_id: int | None = None,
+) -> list[str]:
+    """给 cluster 追加别名。
+
+    幂等：已存在的别名不会重复添加。
+    安全：与同主题内任意 cluster 名字冲突的别名会被拒绝（防止别名变独立 cluster）。
+
+    Args:
+        cluster_id: 目标 cluster 的 id。
+        aliases: 待添加的别名列表。
+        theme_id: 用于冲突检测的主题 id；若为 None 则自动从 cluster 行读取。
+
+    Returns:
+        实际新增（去重、过滤冲突后）的别名列表。
+    """
+    if not aliases:
+        return []
+    if theme_id is None:
+        row = await db.fetch_one(
+            "SELECT theme_id FROM word_pulse_cluster WHERE id = ?", (cluster_id,),
+        )
+        if row is None:
+            return []
+        theme_id = row["theme_id"]
+
+    # 同主题内所有 cluster 名字（包括自己）作为黑名单
+    existing_clusters = await db.fetch_all(
+        "SELECT name FROM word_pulse_cluster WHERE theme_id = ?", (theme_id,),
+    )
+    reserved_names = {r["name"] for r in existing_clusters}
+
+    # 当前别名
+    row = await db.fetch_one(
+        "SELECT aliases_json FROM word_pulse_cluster WHERE id = ?", (cluster_id,),
+    )
+    if row is None:
+        return []
+    try:
+        current = json.loads(row["aliases_json"])
+    except json.JSONDecodeError:
+        current = []
+    current_set = set(current)
+
+    added: list[str] = []
+    for a in aliases:
+        if not a or a in reserved_names or a in current_set:
+            continue
+        current_set.add(a)
+        added.append(a)
+
+    if not added:
+        return []
+    # 保序：旧别名 + 新增别名
+    merged = current + added
+    await db.execute(
+        "UPDATE word_pulse_cluster SET aliases_json = ? WHERE id = ?",
+        (json.dumps(merged, ensure_ascii=False), cluster_id),
+    )
+    return added
+
+
+async def remove_cluster_aliases(cluster_id: int, aliases: list[str]) -> list[str]:
+    """从 cluster 删除别名。
+
+    Args:
+        cluster_id: 目标 cluster 的 id。
+        aliases: 待删除的别名列表。
+
+    Returns:
+        实际被删除的别名列表。
+    """
+    if not aliases:
+        return []
+    row = await db.fetch_one(
+        "SELECT aliases_json FROM word_pulse_cluster WHERE id = ?", (cluster_id,),
+    )
+    if row is None:
+        return []
+    try:
+        current = json.loads(row["aliases_json"])
+    except json.JSONDecodeError:
+        current = []
+    current_set = set(current)
+    to_remove = {a for a in aliases if a in current_set}
+    if not to_remove:
+        return []
+    # 保序：保留未删除的，按原顺序
+    kept = [a for a in current if a not in to_remove]
+    await db.execute(
+        "UPDATE word_pulse_cluster SET aliases_json = ? WHERE id = ?",
+        (json.dumps(kept, ensure_ascii=False), cluster_id),
+    )
+    return sorted(to_remove)
 
 
 # ── Charset ──

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ async def load_plugins(_nonebot_init: None):
     load_plugin("src.plugins.a_share_sentiment")
     load_plugin("src.plugins.un_nickname")
     load_plugin("src.plugins.refine")
+    load_plugin("src.plugins.word_pulse")
 
     from src.plugins.message_archive.db import ensure_schema
     from src.plugins.refine.db import ensure_schema as ensure_refine_schema
@@ -88,6 +89,19 @@ async def reset_message_archive_table() -> None:
     await get_db().execute("DELETE FROM refine_subscription")
     await get_db().execute("DELETE FROM nicknames")
     await get_db().execute("DELETE FROM nickname_collections")
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def reset_word_pulse_tables() -> None:
+    """每个用例前清空 word_pulse 表。"""
+    from src.plugins.word_pulse.db import ensure_schema
+    from src.storage import get_db
+
+    ensure_schema()
+    await get_db().execute("DELETE FROM word_pulse_bucket")
+    await get_db().execute("DELETE FROM word_pulse_charset")
+    await get_db().execute("DELETE FROM word_pulse_cluster")
+    await get_db().execute("DELETE FROM word_pulse_theme")
 
 
 @pytest_asyncio.fixture

--- a/tests/test_message_archive.py
+++ b/tests/test_message_archive.py
@@ -2,7 +2,12 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
-from nonebot.adapters.onebot.v11 import GroupMessageEvent, Message, MessageSegment, PrivateMessageEvent
+from nonebot.adapters.onebot.v11 import (
+    GroupMessageEvent,
+    Message,
+    MessageSegment,
+    PrivateMessageEvent,
+)
 from nonebot.adapters.onebot.v11.event import Sender
 
 
@@ -274,7 +279,7 @@ async def test_archive_persists_image_when_enabled(tmp_path, monkeypatch) -> Non
 @pytest.mark.asyncio
 async def test_archive_skips_image_when_disabled(tmp_path, monkeypatch) -> None:
     """image_enabled=False 时不下载图片。"""
-    from src.plugins.message_archive import image_store, db as archive_db
+    from src.plugins.message_archive import db as archive_db, image_store
     from src.plugins.message_archive.db import archive_message_event
 
     monkeypatch.setattr(image_store, "image_dir", tmp_path)
@@ -298,7 +303,7 @@ async def test_archive_skips_image_when_disabled(tmp_path, monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_archive_caps_image_count(tmp_path, monkeypatch) -> None:
     """单条消息图片数超过 max_count 时只存前 N 张。"""
-    from src.plugins.message_archive import image_store, db as archive_db
+    from src.plugins.message_archive import db as archive_db, image_store
     from src.plugins.message_archive.db import archive_message_event
     from tests.message_store_helpers import make_image_bytes
 

--- a/tests/test_user_visible_errors.py
+++ b/tests/test_user_visible_errors.py
@@ -1,6 +1,10 @@
 def test_anime_trace_failure_messages_are_sanitized() -> None:
     from src.plugins.anime_trace import get_anime_trace_failure_message
-    from src.plugins.anime_trace.exceptions import APIRequestError, APIResponseError, ImageDownloadError
+    from src.plugins.anime_trace.exceptions import (
+        APIRequestError,
+        APIResponseError,
+        ImageDownloadError,
+    )
 
     assert get_anime_trace_failure_message(ImageDownloadError("boom")) == "下载图片失败，请稍后重试"
     assert get_anime_trace_failure_message(APIRequestError("boom")) == "搜番请求失败，请稍后重试"

--- a/tests/test_word_pulse_analysis.py
+++ b/tests/test_word_pulse_analysis.py
@@ -1,0 +1,109 @@
+"""词频插件分析层（classify_message）+ 端到端 alias 行为测试。
+
+classify_message 本身无需修改，它接受任意 cluster_terms。
+alias 行为的端到端验证：cluster_terms 构造时把 alias 并入，
+classify_message 应当对纯 alias 命中的消息返回主名词。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from nonebug import App
+
+
+def test_classify_message_hits_alias_only(app: App) -> None:
+    """消息只含 alias（不含主名词），应归类到主名词。"""
+    from src.plugins.word_pulse.analysis import classify_message
+    char_pool = {"茅", "子", "台", "飞"}
+    # 模拟 _compute_buckets 里 alias 被并入 cluster_terms 后的形态
+    cluster_terms = {
+        "茅台": {"茅台", "茅子", "飞天"},  # 主名词 + aliases
+        "五粮液": {"五粮液"},
+    }
+    # 消息只出现"茅子"，没出现"茅台"
+    assert classify_message("今天茅子涨疯了", char_pool, cluster_terms) == ["茅台"]
+
+
+def test_classify_message_no_hit_returns_none(app: App) -> None:
+    """消息不含 char_pool 任何字符，应返回 None。"""
+    from src.plugins.word_pulse.analysis import classify_message
+    char_pool = {"茅"}
+    cluster_terms = {"茅台": {"茅台"}}
+    assert classify_message("中午吃啥", char_pool, cluster_terms) is None
+
+
+def test_classify_message_char_hit_but_no_term_grey(app: App) -> None:
+    """消息含 char_pool 字符但无 cluster term 命中，返回 GREY。"""
+    from src.plugins.word_pulse.analysis import classify_message
+    char_pool = {"跌", "亏"}
+    cluster_terms = {"涨停": {"涨停"}}
+    assert classify_message("又跌了心态崩了", char_pool, cluster_terms) == "GREY"
+
+
+def test_classify_message_multi_cluster_hit(app: App) -> None:
+    """消息同时命中多个 cluster，返回所有命中的。"""
+    from src.plugins.word_pulse.analysis import classify_message
+    char_pool = {"茅", "五"}
+    cluster_terms = {
+        "茅台": {"茅台", "茅子"},
+        "五粮液": {"五粮液"},
+    }
+    msg = "茅子和五粮液都涨"
+    hits = classify_message(msg, char_pool, cluster_terms)
+    assert hits is not None
+    assert set(hits) == {"茅台", "五粮液"}
+
+
+# ── classify_batch prompt 是否带 alias（白盒验证 ai.py 调用参数）──
+
+
+@pytest.mark.asyncio
+async def test_classify_batch_prompt_includes_aliases(app: App) -> None:
+    """GREY 阶段 LLM 调用时，cluster 列表应带别名提示。"""
+    from src.plugins.word_pulse.ai import classify_batch
+
+    captured_messages: list[list[dict]] = []
+
+    async def fake_request(*, messages, **_):
+        captured_messages.append(messages)
+        return {"results": [{"id": 1, "cluster": "茅台"}]}
+
+    with patch("src.plugins.word_pulse.ai._request_llm", new=AsyncMock(side_effect=fake_request)):
+        await classify_batch(
+            base_url="x", api_key="x", model="x",
+            messages=[(1, "今天茅子涨疯了")],
+            clusters=[{"name": "茅台", "aliases": ["茅子", "飞天"]}],
+            theme_name="炒股",
+        )
+
+    assert len(captured_messages) == 1
+    user_msg = captured_messages[0][1]["content"]  # system=0, user=1
+    # cluster 描述里必须出现"茅子""飞天"作为"茅台"的别名
+    assert "茅子" in user_msg
+    assert "飞天" in user_msg
+    assert "茅台" in user_msg
+
+
+@pytest.mark.asyncio
+async def test_classify_batch_prompt_omits_aliases_section_when_empty(app: App) -> None:
+    """cluster 没有 alias 时，prompt 不应出现"别名"字样。"""
+    from src.plugins.word_pulse.ai import classify_batch
+
+    captured_messages: list[list[dict]] = []
+
+    async def fake_request(*, messages, **_):
+        captured_messages.append(messages)
+        return {"results": [{"id": 1, "cluster": None}]}
+
+    with patch("src.plugins.word_pulse.ai._request_llm", new=AsyncMock(side_effect=fake_request)):
+        await classify_batch(
+            base_url="x", api_key="x", model="x",
+            messages=[(1, "闲聊")],
+            clusters=[{"name": "茅台", "aliases": []}],
+            theme_name="炒股",
+        )
+
+    user_msg = captured_messages[0][1]["content"]
+    assert "别名" not in user_msg

--- a/tests/test_word_pulse_commands.py
+++ b/tests/test_word_pulse_commands.py
@@ -1,0 +1,120 @@
+"""词频插件命令解析测试。
+
+覆盖：add / append / list / del / refresh / alias / unalias 七个子命令。
+
+通过 nonebug `app` fixture 触发 NoneBot 初始化，避免 collect 阶段触发
+插件包 __init__.py 链式导入时报 driver 未初始化错误。
+"""
+
+from __future__ import annotations
+
+import pytest
+from nonebug import App
+
+
+@pytest.fixture
+def parse_command(app: App):
+    """延迟导入 parse_command，确保 NoneBot 已初始化。"""
+    from src.plugins.word_pulse.commands import parse_command as _pc
+    return _pc
+
+
+def test_parse_add_basic(app: App, parse_command) -> None:
+    cmd = parse_command("词频 add 炒股 茅台 五粮液 创业板")
+    assert cmd is not None
+    assert cmd.action == "add"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds == ["茅台", "五粮液", "创业板"]
+
+
+def test_parse_add_single_seed(app: App, parse_command) -> None:
+    cmd = parse_command("词频 add 游戏 原神")
+    assert cmd is not None
+    assert cmd.action == "add"
+    assert cmd.theme == "游戏"
+    assert cmd.seeds == ["原神"]
+
+
+def test_parse_append(app: App, parse_command) -> None:
+    cmd = parse_command("词频 append 炒股 中信证券")
+    assert cmd is not None
+    assert cmd.action == "append"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds == ["中信证券"]
+
+
+def test_parse_list(app: App, parse_command) -> None:
+    cmd = parse_command("词频 list")
+    assert cmd is not None
+    assert cmd.action == "list"
+    assert cmd.theme is None
+    assert cmd.seeds is None
+
+
+def test_parse_del_theme(app: App, parse_command) -> None:
+    cmd = parse_command("词频 del 炒股")
+    assert cmd is not None
+    assert cmd.action == "del"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds is None
+
+
+def test_parse_del_cluster(app: App, parse_command) -> None:
+    cmd = parse_command("词频 del 炒股 茅台")
+    assert cmd is not None
+    assert cmd.action == "del"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds == ["茅台"]
+
+
+def test_parse_refresh(app: App, parse_command) -> None:
+    cmd = parse_command("词频 refresh 炒股")
+    assert cmd is not None
+    assert cmd.action == "refresh"
+    assert cmd.theme == "炒股"
+
+
+def test_parse_alias_basic(app: App, parse_command) -> None:
+    cmd = parse_command("词频 alias 炒股 茅台 茅子 飞天")
+    assert cmd is not None
+    assert cmd.action == "alias"
+    assert cmd.theme == "炒股"
+    # 第一个是主名词，其余是别名
+    assert cmd.seeds == ["茅台", "茅子", "飞天"]
+
+
+def test_parse_alias_multiple_aliases(app: App, parse_command) -> None:
+    cmd = parse_command("词频 alias 炒股 茅台 茅子 飞天 茅茅子 茅神")
+    assert cmd is not None
+    assert cmd.action == "alias"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds == ["茅台", "茅子", "飞天", "茅茅子", "茅神"]
+
+
+def test_parse_alias_requires_at_least_two_args(app: App, parse_command) -> None:
+    """alias 必须包含主名词 + 至少一个别名。"""
+    assert parse_command("词频 alias 炒股 茅台") is None
+
+
+def test_parse_unalias_basic(app: App, parse_command) -> None:
+    cmd = parse_command("词频 unalias 炒股 茅台 茅子")
+    assert cmd is not None
+    assert cmd.action == "unalias"
+    assert cmd.theme == "炒股"
+    assert cmd.seeds == ["茅台", "茅子"]
+
+
+def test_parse_unalias_requires_at_least_two_args(app: App, parse_command) -> None:
+    assert parse_command("词频 unalias 炒股 茅台") is None
+
+
+def test_parse_unknown_action_returns_none(app: App, parse_command) -> None:
+    assert parse_command("词频 foobar 炒股 茅台") is None
+
+
+def test_parse_no_prefix_returns_none(app: App, parse_command) -> None:
+    assert parse_command("总结 7天 炒股") is None
+
+
+def test_parse_empty_returns_none(app: App, parse_command) -> None:
+    assert parse_command("") is None

--- a/tests/test_word_pulse_db.py
+++ b/tests/test_word_pulse_db.py
@@ -1,0 +1,122 @@
+"""词频插件 db 层测试。
+
+覆盖 cluster 的 alias 增删查、aliases 在 get_clusters 中的返回。
+"""
+
+from __future__ import annotations
+
+import pytest
+from nonebug import App
+
+
+@pytest.fixture
+async def word_pulse_db(app: App):
+    """初始化 word_pulse schema 并返回 db 模块。"""
+    from src.plugins.word_pulse import db as wp_db
+    wp_db.ensure_schema()
+    return wp_db
+
+
+def _theme_id_seed(wp_db, gid: str = "g1", name: str = "炒股") -> int:
+    """同步辅助：用 asyncio.run 创建 theme（仅测试）。"""
+    import asyncio
+    return asyncio.run(wp_db.upsert_theme(gid, name))
+
+
+@pytest.mark.asyncio
+async def test_get_clusters_returns_empty_aliases_by_default(word_pulse_db) -> None:
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台", "五粮液"])
+    clusters = await wp_db.get_clusters(tid)
+    assert len(clusters) == 2
+    for c in clusters:
+        assert c["aliases"] == []
+
+
+@pytest.mark.asyncio
+async def test_add_cluster_aliases_persists(word_pulse_db) -> None:
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台"])
+    cluster = (await wp_db.get_clusters(tid))[0]
+
+    await wp_db.add_cluster_aliases(cluster["id"], ["茅子", "飞天"])
+
+    refreshed = (await wp_db.get_clusters(tid))[0]
+    assert refreshed["aliases"] == ["茅子", "飞天"]
+
+
+@pytest.mark.asyncio
+async def test_add_cluster_aliases_idempotent(word_pulse_db) -> None:
+    """重复添加同一别名不应重复。"""
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台"])
+    cid = (await wp_db.get_clusters(tid))[0]["id"]
+
+    await wp_db.add_cluster_aliases(cid, ["茅子", "飞天"])
+    await wp_db.add_cluster_aliases(cid, ["飞天", "茅茅子"])  # 飞天 已存在
+
+    aliases = (await wp_db.get_clusters(tid))[0]["aliases"]
+    assert sorted(aliases) == ["茅子", "茅茅子", "飞天"]
+
+
+@pytest.mark.asyncio
+async def test_add_cluster_aliases_does_not_touch_cluster_name(word_pulse_db) -> None:
+    """别名不能与任何现有 cluster name 冲突（防止别名变独立 cluster）。"""
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台", "五粮液"])
+    maotai = next(c for c in await wp_db.get_clusters(tid) if c["name"] == "茅台")
+
+    # 试图把"五粮液"加成"茅台"的别名 —— 应该被拒绝
+    added = await wp_db.add_cluster_aliases(maotai["id"], ["五粮液"])
+    assert added == []  # 无效别名被过滤
+
+    refreshed = (await wp_db.get_clusters(tid))
+    maotai_after = next(c for c in refreshed if c["name"] == "茅台")
+    assert maotai_after["aliases"] == []
+
+
+@pytest.mark.asyncio
+async def test_remove_cluster_aliases(word_pulse_db) -> None:
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台"])
+    cid = (await wp_db.get_clusters(tid))[0]["id"]
+
+    await wp_db.add_cluster_aliases(cid, ["茅子", "飞天", "茅茅子"])
+    removed = await wp_db.remove_cluster_aliases(cid, ["茅子", "飞天"])
+
+    assert sorted(removed) == ["茅子", "飞天"]
+    remaining = (await wp_db.get_clusters(tid))[0]["aliases"]
+    assert remaining == ["茅茅子"]
+
+
+@pytest.mark.asyncio
+async def test_remove_cluster_aliases_nonexistent_silently_ignored(word_pulse_db) -> None:
+    """删除不存在的别名不应报错，返回实际删除的（空）。"""
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台"])
+    cid = (await wp_db.get_clusters(tid))[0]["id"]
+
+    await wp_db.add_cluster_aliases(cid, ["茅子"])
+    removed = await wp_db.remove_cluster_aliases(cid, ["不存在的别名"])
+    assert removed == []
+    assert (await wp_db.get_clusters(tid))[0]["aliases"] == ["茅子"]
+
+
+@pytest.mark.asyncio
+async def test_delete_cluster_cascades_aliases(word_pulse_db) -> None:
+    """删除 cluster 时别名也应一并清掉（虽然 cluster 没了，主要测不报错）。"""
+    wp_db = word_pulse_db
+    tid = await wp_db.upsert_theme("g1", "炒股")
+    await wp_db.replace_clusters(tid, ["茅台"])
+    cid = (await wp_db.get_clusters(tid))[0]["id"]
+    await wp_db.add_cluster_aliases(cid, ["茅子"])
+
+    await wp_db.delete_cluster(cid)
+
+    assert await wp_db.get_clusters(tid) == []


### PR DESCRIPTION
## 背景

word_pulse 插件原始模型里每个种子词 = 一个独立 cluster。炒股场景下用户写 `词频 add 炒股 茅台 茅子 飞天` 时，「茅台/茅子/飞天」会被当成 3 个独立 cluster 分别统计——热度被拆散。AI 字符集扩展只产单字，对多字别名（黑话/谐音梗）完全无效，且不可控。

## 改动

### 1. cluster alias 模型（核心）

- `word_pulse_cluster` 新增 `aliases_json` 列（老库通过 `ensure_schema` 自动 `ALTER TABLE` 迁移）
- 命令：`词频 alias 炒股 茅台 茅子 飞天` / `词频 unalias 炒股 茅台 茅子`
- 别名安全：禁止把已存在的 cluster 名字加成别名（避免别名变独立 cluster）
- alias 增删后自动 `delete_buckets_by_theme` 让旧日桶重算

### 2. 抓取/归类接入别名

- **弱预筛阶段**（`cluster_terms`）：`{主名词} | {主名词, *aliases}`，纯别名消息直接归到主名词
- **粗筛字符池**：别名里的字也并入 `char_pool`，保证别名消息不会被粗筛跳过
- **灰区 LLM 阶段**（`classify_batch` prompt）：cluster 行显示 `(别名: a, b)`，让 AI 把别名等同主名词处理

### 3. 精简配置

删除 7 个细枝末节配置项，硬编码为模块级常量：
- `temperature` / `summary_temperature` / `timeout_seconds`
- `cooldown_seconds` / `cache_ttl_minutes` / `today_bucket_fresh_seconds`
- `max_examples_in_summary`

保留 8 项真正影响行为/成本的配置：`plugin_enabled` / `base_url` / `api_key` / `model` / `bucket_retention_days` / `max_messages_per_bucket` / `max_sample_per_cluster` / `max_window_days`。

### 4. 测试

新增 3 个测试文件，28 个用例：
- `test_word_pulse_commands.py` — 命令解析（15）
- `test_word_pulse_db.py` — alias CRUD + 冲突检测（7）
- `test_word_pulse_analysis.py` — classify_message 别名命中 + classify_batch prompt 含 alias（6）

## 验证

```
uv run ruff check .    → 17 errors（baseline，无新增）
uv run pyright         → 0 errors, 0 warnings
uv run pytest          → 28 新增全绿；a_share_sentiment 既有失败与本 PR 无关
``

## 用法示例

```
词频 add 炒股 茅台 五粮液 创业板
词频 alias 炒股 茅台 茅子 飞天 茅茅子 茅神
词频 alias 炒股 五粮液 五粮 普五
词频 list
  📊 本群主题列表：
    · 炒股 / 茅台（别名: 茅子、飞天、茅茅子、茅神）
    · 炒股 / 五粮液（别名: 五粮、普五）
    · 炒股 / 创业板
```

最终 ranking 里只会看到「茅台 / 五粮液 / 创业板」3 个 cluster，所有别名消息的热度收拢到主名词。